### PR TITLE
Improve appender speed v2

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"runtime"
 	"sync"
 
 	"github.com/duckdb/duckdb-go/v2/mapping"
+	"golang.org/x/sync/errgroup"
 )
 
 type (
@@ -428,70 +430,46 @@ func (a *Appender) initAppenderChunk() (*Appender, error) {
 	return a, nil
 }
 
+// AppendTableSource appends an AppenderSource to the appender. Repeatedly calls `FillRow` or
+// `FillChunk` depending on the AppenderSource type. If an error is returned, any data
+// inserted by that call to `FillRow` or `FillChunk` is ignored. Any previous calls to either
+// of these functions will be processed and appended.
 func (a *Appender) AppendTableSource(s AppenderSource) error {
+	var runParallel = func(maxThreads int, worker func() error) error {
+		g := errgroup.Group{}
+		for range min(maxThreads, runtime.GOMAXPROCS(-1)) {
+			g.Go(worker)
+		}
+		return g.Wait()
+	}
+
 	lock := &sync.Mutex{}
 	// projection is not used in chunk, so we must keep it a 1-1 mapping
 	columnCount := mapping.AppenderColumnCount(a.appender)
 	projection := make([]int, 0, columnCount)
-	for i := mapping.IdxT(0); i < columnCount; i++ {
+	for i := range columnCount {
 		projection = append(projection, int(i))
 	}
-	var x any = s
-	switch s := x.(type) {
+	switch s := s.(type) {
 	case rowAppenderSource:
 		s.Source.Init()
-		err := appenderRowThread(&parallelRowTSWrapper{s.Source}, lock, a.types, a.appender, projection)
-		if err != nil {
-			return err
-		}
+		return appenderRowThread(&parallelRowTSWrapper{s.Source}, lock, a.types, a.appender, projection)
 	case parallelRowAppenderSource:
-		wg := sync.WaitGroup{}
-
 		info := s.Source.Init()
-		threads := min(info.MaxThreads, runtime.GOMAXPROCS(-1))
-		var oerr error
-		for range threads {
-			wg.Add(1)
-			go func() {
-				err := appenderRowThread(s.Source, lock, a.types, a.appender, projection)
-				if err != nil {
-					oerr = err
-				}
-				wg.Done()
-			}()
-		}
-		wg.Wait()
-		if oerr != nil {
-			return oerr
-		}
+		return runParallel(info.MaxThreads, func() error {
+			return appenderRowThread(s.Source, lock, a.types, a.appender, projection)
+		})
 	case chunkAppenderSource:
 		s.Source.Init()
-		err := appenderChunkThread(&parallelChunkTSWrapper{s.Source}, lock, a.types, a.appender)
-		if err != nil {
-			return err
-		}
+		return appenderChunkThread(&parallelChunkTSWrapper{s.Source}, lock, a.types, a.appender)
 	case parallelChunkAppenderSource:
-		wg := sync.WaitGroup{}
-
 		info := s.Source.Init()
-		threads := min(info.MaxThreads, runtime.GOMAXPROCS(-1))
-		var oerr error
-		for range threads {
-			wg.Add(1)
-			go func() {
-				err := appenderChunkThread(s.Source, lock, a.types, a.appender)
-				if err != nil {
-					oerr = err
-				}
-				wg.Done()
-			}()
-		}
-		wg.Wait()
-		if oerr != nil {
-			return oerr
-		}
+		return runParallel(info.MaxThreads, func() error {
+			return appenderChunkThread(s.Source, lock, a.types, a.appender)
+		})
+	default:
+		return fmt.Errorf("unknown AppenderSource type: %T. Must be created with NewAppenderRowSource, NewAppenderParallelRowSource, NewAppenderChunkSource, or NewAppenderParallelChunkSource", s)
 	}
-	return nil
 }
 
 func (a *Appender) appendRowSlice(args []driver.Value) error {
@@ -579,6 +557,7 @@ func appenderRowThread(s ParallelRowTableSource, lock *sync.Mutex, types []mappi
 	if err != nil {
 		return err
 	}
+	defer chunk.close()
 	chunk.projection = projection
 
 	for {
@@ -587,13 +566,10 @@ func appenderRowThread(s ParallelRowTableSource, lock *sync.Mutex, types []mappi
 			rowIdx: 0,
 		}
 		var next bool
+		var err error
 		for ; row.rowIdx < mapping.IdxT(maxSize); row.rowIdx++ {
 			next, err = s.FillRow(lstate, row)
-			if err != nil {
-				chunk.close()
-				return err
-			}
-			if !next {
+			if err != nil || !next {
 				break
 			}
 		}
@@ -608,12 +584,14 @@ func appenderRowThread(s ParallelRowTableSource, lock *sync.Mutex, types []mappi
 			return err
 		}
 		lock.Unlock()
+		if err != nil {
+			return err
+		}
 		if !next {
 			break
 		}
 		chunk.reset(true)
 	}
-	chunk.close()
 	return nil
 }
 
@@ -624,15 +602,13 @@ func appenderChunkThread(s ParallelChunkTableSource, lock *sync.Mutex, types []m
 	if err != nil {
 		return err
 	}
-
+	defer chunk.close()
 	for {
 		err = s.FillChunk(lstate, chunk)
 		if err != nil {
 			return err
 		}
-
 		if chunk.GetSize() == 0 {
-			chunk.close()
 			break
 		}
 
@@ -646,7 +622,7 @@ func appenderChunkThread(s ParallelChunkTableSource, lock *sync.Mutex, types []m
 		lock.Unlock()
 		chunk.reset(true)
 	}
-	chunk.close()
+
 	return nil
 }
 

--- a/appender.go
+++ b/appender.go
@@ -4,27 +4,44 @@ import (
 	"context"
 	"database/sql/driver"
 	"errors"
+	"runtime"
+	"sync"
 
 	"github.com/duckdb/duckdb-go/v2/mapping"
 )
 
-// Appender wraps functionality around the DuckDB appender.
-// It enables efficient bulk transformations.
-type Appender struct {
-	// The raw sql.Conn's driver connection.
-	conn *Conn
-	// The DuckDB appender.
-	appender mapping.Appender
-	// True, if the appender has been closed.
-	closed bool
+type (
+	appenderSource[T any] struct {
+		Source T
+	}
 
-	// The chunk to append to.
-	chunk DataChunk
-	// The column types of the table to append to.
-	types []mapping.LogicalType
-	// The number of appended rows.
-	rowCount int
-}
+	rowAppenderSource           = appenderSource[RowTableSource]
+	parallelRowAppenderSource   = appenderSource[ParallelRowTableSource]
+	chunkAppenderSource         = appenderSource[ChunkTableSource]
+	parallelChunkAppenderSource = appenderSource[ParallelChunkTableSource]
+
+	AppenderSource interface {
+		_secret()
+	}
+
+	// Appender wraps functionality around the DuckDB appender.
+	// It enables efficient bulk transformations.
+	Appender struct {
+		// The raw sql.Conn's driver connection.
+		conn *Conn
+		// The DuckDB appender.
+		appender mapping.Appender
+		// True, if the appender has been closed.
+		closed bool
+
+		// The chunk to append to.
+		chunk DataChunk
+		// The column types of the table to append to.
+		types []mapping.LogicalType
+		// The number of appended rows.
+		rowCount int
+	}
+)
 
 // NewAppenderFromConn returns a new Appender for the default catalog.
 // The Appender batches rows via AppendRow. Upon reaching the auto-flush threshold or
@@ -411,6 +428,72 @@ func (a *Appender) initAppenderChunk() (*Appender, error) {
 	return a, nil
 }
 
+func (a *Appender) AppendTableSource(s AppenderSource) error {
+	lock := &sync.Mutex{}
+	// projection is not used in chunk, so we must keep it a 1-1 mapping
+	columnCount := mapping.AppenderColumnCount(a.appender)
+	projection := make([]int, 0, columnCount)
+	for i := mapping.IdxT(0); i < columnCount; i++ {
+		projection = append(projection, int(i))
+	}
+	var x any = s
+	switch s := x.(type) {
+	case rowAppenderSource:
+		s.Source.Init()
+		err := appenderRowThread(&parallelRowTSWrapper{s.Source}, lock, a.types, a.appender, projection)
+		if err != nil {
+			return err
+		}
+	case parallelRowAppenderSource:
+		wg := sync.WaitGroup{}
+
+		info := s.Source.Init()
+		threads := min(info.MaxThreads, runtime.GOMAXPROCS(-1))
+		var oerr error
+		for range threads {
+			wg.Add(1)
+			go func() {
+				err := appenderRowThread(s.Source, lock, a.types, a.appender, projection)
+				if err != nil {
+					oerr = err
+				}
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+		if oerr != nil {
+			return oerr
+		}
+	case chunkAppenderSource:
+		s.Source.Init()
+		err := appenderChunkThread(&parallelChunkTSWrapper{s.Source}, lock, a.types, a.appender)
+		if err != nil {
+			return err
+		}
+	case parallelChunkAppenderSource:
+		wg := sync.WaitGroup{}
+
+		info := s.Source.Init()
+		threads := min(info.MaxThreads, runtime.GOMAXPROCS(-1))
+		var oerr error
+		for range threads {
+			wg.Add(1)
+			go func() {
+				err := appenderChunkThread(s.Source, lock, a.types, a.appender)
+				if err != nil {
+					oerr = err
+				}
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+		if oerr != nil {
+			return oerr
+		}
+	}
+	return nil
+}
+
 func (a *Appender) appendRowSlice(args []driver.Value) error {
 	// Early-out, if the number of args does not match the column count.
 	if len(args) != len(a.types) {
@@ -486,4 +569,101 @@ func (a *Appender) flushWithCancel(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func appenderRowThread(s ParallelRowTableSource, lock *sync.Mutex, types []mapping.LogicalType, duckdbAppender mapping.Appender, projection []int) error {
+	maxSize := GetDataChunkCapacity()
+	lstate := s.NewLocalState()
+	var chunk DataChunk
+	err := chunk.initFromTypes(types, true)
+	if err != nil {
+		return err
+	}
+	chunk.projection = projection
+
+	for {
+		row := Row{
+			chunk:  &chunk,
+			rowIdx: 0,
+		}
+		var next bool
+		for ; row.rowIdx < mapping.IdxT(maxSize); row.rowIdx++ {
+			next, err = s.FillRow(lstate, row)
+			if err != nil {
+				chunk.close()
+				return err
+			}
+			if !next {
+				break
+			}
+		}
+
+		mapping.DataChunkSetSize(chunk.chunk, row.rowIdx)
+
+		lock.Lock()
+		state := mapping.AppendDataChunk(duckdbAppender, chunk.chunk)
+		if state == mapping.StateError {
+			err := getDuckDBError(mapping.AppenderError(duckdbAppender))
+			lock.Unlock()
+			return err
+		}
+		lock.Unlock()
+		if !next {
+			break
+		}
+		chunk.reset(true)
+	}
+	chunk.close()
+	return nil
+}
+
+func appenderChunkThread(s ParallelChunkTableSource, lock *sync.Mutex, types []mapping.LogicalType, duckdbAppender mapping.Appender) error {
+	lstate := s.NewLocalState()
+	var chunk DataChunk
+	err := chunk.initFromTypes(types, true)
+	if err != nil {
+		return err
+	}
+
+	for {
+		err = s.FillChunk(lstate, chunk)
+		if err != nil {
+			return err
+		}
+
+		if chunk.GetSize() == 0 {
+			chunk.close()
+			break
+		}
+
+		lock.Lock()
+		state := mapping.AppendDataChunk(duckdbAppender, chunk.chunk)
+		if state == mapping.StateError {
+			err := getDuckDBError(mapping.AppenderError(duckdbAppender))
+			lock.Unlock()
+			return err
+		}
+		lock.Unlock()
+		chunk.reset(true)
+	}
+	chunk.close()
+	return nil
+}
+
+func (a appenderSource[T]) _secret() {}
+
+func NewAppenderRowSource(source RowTableSource) AppenderSource {
+	return rowAppenderSource{Source: source}
+}
+
+func NewAppenderParallelRowSource(source ParallelRowTableSource) AppenderSource {
+	return parallelRowAppenderSource{Source: source}
+}
+
+func NewAppenderChunkSource(source ChunkTableSource) AppenderSource {
+	return chunkAppenderSource{Source: source}
+}
+
+func NewAppenderParallelChunkSource(source ParallelChunkTableSource) AppenderSource {
+	return parallelChunkAppenderSource{Source: source}
 }

--- a/appender_test.go
+++ b/appender_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -1774,6 +1775,7 @@ type (
 	appStructTableUDF struct {
 		n     int64
 		count int64
+		err   error // return this when done. Could be nil
 	}
 
 	appParStructTableUDF struct {
@@ -1784,11 +1786,9 @@ type (
 )
 
 func (udf *appStructTableUDF) ColumnInfos() []ColumnInfo {
-	t, _ := NewTypeInfo(TYPE_BIGINT)
-	t2, _ := NewTypeInfo(TYPE_UTINYINT)
 	return []ColumnInfo{
-		{Name: "id", T: t},
-		{Name: "uint8", T: t2},
+		{Name: "id", T: typeBigintTableUDF},
+		{Name: "uint8", T: typeUTinyintTableUDF},
 	}
 }
 
@@ -1796,7 +1796,7 @@ func (udf *appStructTableUDF) Init() {}
 
 func (udf *appStructTableUDF) FillRow(row Row) (bool, error) {
 	if udf.count >= udf.n {
-		return false, nil
+		return false, udf.err
 	}
 	udf.count++
 	err := SetRowValue(row, 0, udf.count)
@@ -1824,7 +1824,10 @@ func (udf *appStructTableUDF) Cardinality() *CardinalityInfo {
 }
 
 func (udf *appParStructTableUDF) ColumnInfos() []ColumnInfo {
-	return []ColumnInfo{{Name: "result", T: typeBigintTableUDF}}
+	return []ColumnInfo{
+		{Name: "result", T: typeBigintTableUDF},
+		{Name: "result2", T: typeBigintTableUDF},
+	}
 }
 
 func (udf *appParStructTableUDF) Init() ParallelTableSourceInfo {
@@ -1867,7 +1870,6 @@ func (udf *appParStructTableUDF) FillRow(localState any, row Row) (bool, error) 
 	}
 	err = SetRowValue(row, 1, state.start)
 	return true, err
-
 }
 
 func (udf *appParStructTableUDF) GetValue(r, c int) any {
@@ -1918,16 +1920,17 @@ func TestAppendParallelRowSource(t *testing.T) {
 		args[i] = &values[i]
 	}
 
-	count := 0
+	count := int64(0)
 	for r := 0; res.Next(); r++ {
 		require.NoError(t, res.Scan(args...))
 		for i, value := range values {
 			expected := f.GetValue(r, i)
-			require.Equal(t, expected, value, "incorrect value", r, i)
+			require.Equal(t, expected, value, "incorrect value at row %v column %v", r, i)
 		}
 		count++
 	}
 	cleanupAppender(t, c, db, con, a)
+	require.Equal(t, f.n, count, "number of rows should be equal")
 }
 
 func TestAppendParallelRowSourceSingle(t *testing.T) {
@@ -1960,18 +1963,17 @@ func TestAppendParallelRowSourceSingle(t *testing.T) {
 		args[i] = &values[i]
 	}
 
-	count := 0
+	count := int64(0)
 	for r := 0; res.Next(); r++ {
 		require.NoError(t, res.Scan(args...))
 		for i, value := range values {
 			expected := f.GetValue(r, i)
-			//fmt.Println(args)
-			//fmt.Println(expected, value)
 			require.Equal(t, expected, value, "incorrect value", r, i)
 		}
 		count++
 	}
 	cleanupAppender(t, c, db, con, a)
+	require.Equal(t, f.n, count, "number of rows should be correct")
 }
 
 func TestAppendRowSource(t *testing.T) {
@@ -2003,7 +2005,7 @@ func TestAppendRowSource(t *testing.T) {
 		args[i] = &values[i]
 	}
 
-	count := 0
+	count := int64(0)
 	for r := 0; res.Next(); r++ {
 		require.NoError(t, res.Scan(args...))
 		for i, value := range values {
@@ -2013,6 +2015,95 @@ func TestAppendRowSource(t *testing.T) {
 		count++
 	}
 	cleanupAppender(t, c, db, con, a)
+	require.Equal(t, f.n, count, "number of rows should be equal")
+}
+
+func TestAppendRowSourceError(t *testing.T) {
+	t.Parallel()
+	sc := `
+		CREATE TABLE test (
+			id BIGINT,
+			uint8 UTINYINT
+	  	)`
+	c, db, con, a := prepareAppender(t, appenderTypeDefault, sc)
+
+	f := appStructTableUDF{
+		n:   3000,
+		err: errors.New("Test test"),
+	}
+
+	err := a.AppendTableSource(NewAppenderRowSource(&f))
+	require.Equal(t, err, f.err)
+
+	err = a.Flush()
+	require.NoError(t, err)
+
+	// Verify results.
+	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT * FROM test ORDER BY id`)
+	require.NoError(t, err)
+
+	values := f.GetTypes()
+	args := make([]any, len(values))
+	for i := range values {
+		args[i] = &values[i]
+	}
+
+	count := int64(0)
+	for r := 0; res.Next(); r++ {
+		require.NoError(t, res.Scan(args...))
+		for i, value := range values {
+			expected := f.GetValue(r, i)
+			require.Equal(t, expected, value, "incorrect value", r, i)
+		}
+		count++
+	}
+	cleanupAppender(t, c, db, con, a)
+	require.Equal(t, f.n, count, "number of rows should be equal")
+}
+
+func roundDownChunk[T int64 | int](x T) T {
+	return (x / 2048) * 2048
+}
+
+func TestAppendChunkSourceError(t *testing.T) {
+	t.Parallel()
+	sc := `
+		CREATE TABLE test (
+			id BIGINT,
+	  	)`
+	c, db, con, a := prepareAppender(t, appenderTypeDefault, sc)
+
+	f := chunkIncTableUDF{
+		n:   3000,
+		err: errors.New("Test test"),
+	}
+	err := a.AppendTableSource(NewAppenderChunkSource(&f))
+	require.Equal(t, err, f.err)
+
+	err = a.Flush()
+	require.NoError(t, err)
+
+	// Verify results.
+	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT * FROM test ORDER BY id`)
+	require.NoError(t, err)
+
+	values := f.GetTypes()
+	args := make([]any, len(values))
+	for i := range values {
+		args[i] = &values[i]
+	}
+
+	count := int64(0)
+	for r := 0; res.Next(); r++ {
+		require.NoError(t, res.Scan(args...))
+		for i, value := range values {
+			expected := f.GetValue(r, i)
+			require.Equal(t, expected, value, "incorrect value", r, i)
+		}
+		count++
+	}
+	cleanupAppender(t, c, db, con, a)
+	require.Equal(t, roundDownChunk(f.n), count, "number of rows should be equal")
 }
 
 func BenchmarkAppenderNested(b *testing.B) {
@@ -2170,7 +2261,7 @@ func benchmarkAppenderSingle[T any](v T) func(*testing.B) {
 		tableSQL := fmt.Sprintf(createSingleTableSQL, types[reflect.TypeFor[T]()])
 		c, db, con, a := prepareAppender(b, appenderTypeDefault, tableSQL)
 
-		var vec [benchmarkRowsToAppend]T = [benchmarkRowsToAppend]T{}
+		vec := [benchmarkRowsToAppend]T{}
 		for i := range benchmarkRowsToAppend {
 			vec[i] = v
 		}

--- a/appender_test.go
+++ b/appender_test.go
@@ -11,6 +11,7 @@ import (
 	"math/rand"
 	"os"
 	"strings"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -91,6 +92,8 @@ type resultRow struct {
 	mix                 any
 	mixList             []any
 }
+
+const benchmarkRowsToAppend = 2048 * 128
 
 func castList[T any](val []any) []T {
 	res := make([]T, len(val))
@@ -1767,13 +1770,257 @@ func TestEmbeddedNulls(t *testing.T) {
 	}
 }
 
+type (
+	appStructTableUDF struct {
+		n     int64
+		count int64
+	}
+
+	appParStructTableUDF struct {
+		lock    *sync.Mutex
+		claimed int64
+		n       int64
+	}
+)
+
+func (udf *appStructTableUDF) ColumnInfos() []ColumnInfo {
+	t, _ := NewTypeInfo(TYPE_BIGINT)
+	t2, _ := NewTypeInfo(TYPE_UTINYINT)
+	return []ColumnInfo{
+		{Name: "id", T: t},
+		{Name: "uint8", T: t2},
+	}
+}
+
+func (udf *appStructTableUDF) Init() {}
+
+func (udf *appStructTableUDF) FillRow(row Row) (bool, error) {
+	if udf.count >= udf.n {
+		return false, nil
+	}
+	udf.count++
+	err := SetRowValue(row, 0, udf.count)
+	if err != nil {
+		return true, err
+	}
+	err = SetRowValue(row, 1, udf.count)
+	return true, err
+}
+
+func (udf *appStructTableUDF) GetTypes() []any {
+	return []any{int64(0), uint8(0)}
+}
+
+func (udf *appStructTableUDF) GetValue(r, c int) any {
+	if c == 0 {
+		return int64(r + 1)
+	} else {
+		return uint8(r + 1)
+	}
+}
+
+func (udf *appStructTableUDF) Cardinality() *CardinalityInfo {
+	return nil
+}
+
+func (udf *appParStructTableUDF) ColumnInfos() []ColumnInfo {
+	return []ColumnInfo{{Name: "result", T: typeBigintTableUDF}}
+}
+
+func (udf *appParStructTableUDF) Init() ParallelTableSourceInfo {
+	return ParallelTableSourceInfo{MaxThreads: 8}
+}
+
+func (udf *appParStructTableUDF) NewLocalState() any {
+	return &parallelIncTableLocalState{
+		start: 0,
+		end:   -1,
+	}
+}
+
+func (udf *appParStructTableUDF) FillRow(localState any, row Row) (bool, error) {
+	state := localState.(*parallelIncTableLocalState)
+
+	if state.start >= state.end {
+		// Claim a new work unit.
+		udf.lock.Lock()
+		remaining := udf.n - udf.claimed
+
+		if remaining <= 0 {
+			// No more work.
+			udf.lock.Unlock()
+			return false, nil
+		} else if remaining >= 2024 {
+			remaining = 2024
+		}
+
+		state.start = udf.claimed
+		udf.claimed += remaining
+		state.end = udf.claimed
+		udf.lock.Unlock()
+	}
+
+	state.start++
+	err := SetRowValue(row, 0, state.start)
+	if err != nil {
+		return true, err
+	}
+	err = SetRowValue(row, 1, state.start)
+	return true, err
+
+}
+
+func (udf *appParStructTableUDF) GetValue(r, c int) any {
+	if c == 0 {
+		return int64(r + 1)
+	} else {
+		return uint8(r + 1)
+	}
+}
+
+func (udf *appParStructTableUDF) GetTypes() []any {
+	return []any{int64(0), uint8(0)}
+}
+
+func (udf *appParStructTableUDF) Cardinality() *CardinalityInfo {
+	return nil
+}
+
+func TestAppendParallelRowSource(t *testing.T) {
+	t.Parallel()
+	sc := `
+		CREATE TABLE test (
+			id BIGINT,
+			uint8 UTINYINT
+	  	)`
+
+	c, db, con, a := prepareAppender(t, appenderTypeDefault, sc)
+
+	f := appParStructTableUDF{
+		lock:    &sync.Mutex{},
+		claimed: 0,
+		n:       3000,
+	}
+
+	err := a.AppendTableSource(NewAppenderParallelRowSource(&f))
+	require.NoError(t, err)
+
+	err = a.Flush()
+	require.NoError(t, err)
+
+	// Verify results.
+	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT * FROM test ORDER BY id`)
+	require.NoError(t, err)
+
+	values := f.GetTypes()
+	args := make([]any, len(values))
+	for i := range values {
+		args[i] = &values[i]
+	}
+
+	count := 0
+	for r := 0; res.Next(); r++ {
+		require.NoError(t, res.Scan(args...))
+		for i, value := range values {
+			expected := f.GetValue(r, i)
+			require.Equal(t, expected, value, "incorrect value", r, i)
+		}
+		count++
+	}
+	cleanupAppender(t, c, db, con, a)
+}
+
+func TestAppendParallelRowSourceSingle(t *testing.T) {
+	t.Parallel()
+	sc := `
+		CREATE TABLE test (
+			id BIGINT,
+	  	)`
+
+	c, db, con, a := prepareAppender(t, appenderTypeDefault, sc)
+
+	f := parallelIncTableUDF{
+		lock: &sync.Mutex{},
+		n:    3000,
+	}
+
+	err := a.AppendTableSource(NewAppenderParallelRowSource(&f))
+	require.NoError(t, err)
+
+	err = a.Flush()
+	require.NoError(t, err)
+
+	// Verify results.
+	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT * FROM test ORDER BY id`)
+	require.NoError(t, err)
+
+	values := f.GetTypes()
+	args := make([]any, len(values))
+	for i := range values {
+		args[i] = &values[i]
+	}
+
+	count := 0
+	for r := 0; res.Next(); r++ {
+		require.NoError(t, res.Scan(args...))
+		for i, value := range values {
+			expected := f.GetValue(r, i)
+			//fmt.Println(args)
+			//fmt.Println(expected, value)
+			require.Equal(t, expected, value, "incorrect value", r, i)
+		}
+		count++
+	}
+	cleanupAppender(t, c, db, con, a)
+}
+
+func TestAppendRowSource(t *testing.T) {
+	t.Parallel()
+	sc := `
+		CREATE TABLE test (
+			id BIGINT,
+			uint8 UTINYINT
+	  	)`
+	c, db, con, a := prepareAppender(t, appenderTypeDefault, sc)
+
+	f := appStructTableUDF{
+		n: 3000,
+	}
+
+	err := a.AppendTableSource(NewAppenderRowSource(&f))
+	require.NoError(t, err)
+
+	err = a.Flush()
+	require.NoError(t, err)
+
+	// Verify results.
+	res, err := sql.OpenDB(c).QueryContext(context.Background(), `SELECT * FROM test ORDER BY id`)
+	require.NoError(t, err)
+
+	values := f.GetTypes()
+	args := make([]any, len(values))
+	for i := range values {
+		args[i] = &values[i]
+	}
+
+	count := 0
+	for r := 0; res.Next(); r++ {
+		require.NoError(t, res.Scan(args...))
+		for i, value := range values {
+			expected := f.GetValue(r, i)
+			require.Equal(t, expected, value, "incorrect value", r, i)
+		}
+		count++
+	}
+	cleanupAppender(t, c, db, con, a)
+}
+
 func BenchmarkAppenderNested(b *testing.B) {
 	c, db, conn, a := prepareAppender(b, appenderTypeDefault, createNestedDataTableSQL)
 	defer cleanupAppender(b, c, db, conn, a)
 
 	const rowCount = 600
 	rowsToAppend := prepareNestedData(rowCount)
-
 	b.ResetTimer()
 	for b.Loop() {
 		appendNestedData(b, a, rowsToAppend)
@@ -1910,3 +2157,145 @@ func TestAppenderMapConversion(t *testing.T) {
 	}
 	require.Equal(t, testMap, Map(resultMap))
 }
+
+var types = map[reflect.Type]string{
+	reflect.TypeFor[int8](): "TINYINT",
+}
+
+func benchmarkAppenderSingle[T any](v T) func(*testing.B) {
+	return func(b *testing.B) {
+		if _, ok := types[reflect.TypeFor[T]()]; !ok {
+			b.Fatal("Type not defined in table:", reflect.TypeFor[T]())
+		}
+		tableSQL := fmt.Sprintf(createSingleTableSQL, types[reflect.TypeFor[T]()])
+		c, db, con, a := prepareAppender(b, appenderTypeDefault, tableSQL)
+
+		var vec [benchmarkRowsToAppend]T = [benchmarkRowsToAppend]T{}
+		for i := range benchmarkRowsToAppend {
+			vec[i] = v
+		}
+
+		for b.Loop() {
+			for range benchmarkRowsToAppend {
+				// require took up the majority of the time
+				err := a.AppendRow(v)
+				if err != nil {
+					b.Error(err)
+				}
+			}
+		}
+		cleanupAppender(b, c, db, con, a)
+	}
+}
+
+func benchmarkAppenderRowSingle[T any](_ T) func(*testing.B) {
+	return func(b *testing.B) {
+		if _, ok := types[reflect.TypeFor[T]()]; !ok {
+			b.Fatal("Type not defined in table:", reflect.TypeFor[T]())
+		}
+		tableSQL := fmt.Sprintf(createSingleTableSQL, types[reflect.TypeFor[T]()])
+		c, db, con, a := prepareAppender(b, appenderTypeDefault, tableSQL)
+
+		for b.Loop() {
+			f := incTableUDF{
+				n: benchmarkRowsToAppend,
+			}
+			err := a.AppendTableSource(NewAppenderRowSource(&f))
+			if err != nil {
+				b.Error(err)
+			}
+		}
+		cleanupAppender(b, c, db, con, a)
+	}
+}
+
+func benchmarkAppenderParallelRowSingle[T any](_ T) func(*testing.B) {
+	return func(b *testing.B) {
+		if _, ok := types[reflect.TypeFor[T]()]; !ok {
+			b.Fatal("Type not defined in table:", reflect.TypeFor[T]())
+		}
+		tableSQL := fmt.Sprintf(createSingleTableSQL, types[reflect.TypeFor[T]()])
+		c, db, con, a := prepareAppender(b, appenderTypeDefault, tableSQL)
+
+		for b.Loop() {
+			f := parallelIncTableUDF{
+				lock: &sync.Mutex{},
+				n:    benchmarkRowsToAppend,
+			}
+			err := a.AppendTableSource(NewAppenderParallelRowSource(&f))
+			if err != nil {
+				b.Error(err)
+			}
+		}
+		cleanupAppender(b, c, db, con, a)
+	}
+}
+
+func benchmarkAppenderChunkSingle[T any](_ T) func(*testing.B) {
+	return func(b *testing.B) {
+		if _, ok := types[reflect.TypeFor[T]()]; !ok {
+			b.Fatal("Type not defined in table:", reflect.TypeFor[T]())
+		}
+		tableSQL := fmt.Sprintf(createSingleTableSQL, types[reflect.TypeFor[T]()])
+		c, db, con, a := prepareAppender(b, appenderTypeDefault, tableSQL)
+
+		for b.Loop() {
+			f := chunkIncTableUDF{
+				n: benchmarkRowsToAppend,
+			}
+			err := a.AppendTableSource(NewAppenderChunkSource(&f))
+			if err != nil {
+				b.Error(err)
+			}
+		}
+		cleanupAppender(b, c, db, con, a)
+	}
+}
+
+func benchmarkAppenderParallelChunkSingle[T any](_ T) func(*testing.B) {
+	return func(b *testing.B) {
+		if _, ok := types[reflect.TypeFor[T]()]; !ok {
+			b.Fatal("Type not defined in table:", reflect.TypeFor[T]())
+		}
+		tableSQL := fmt.Sprintf(createSingleTableSQL, types[reflect.TypeFor[T]()])
+		c, db, con, a := prepareAppender(b, appenderTypeDefault, tableSQL)
+
+		for b.Loop() {
+			f := parallelChunkIncTableUDF{
+				lock: &sync.Mutex{},
+				n:    benchmarkRowsToAppend,
+			}
+			err := a.AppendTableSource(NewAppenderParallelChunkSource(&f))
+			if err != nil {
+				b.Error(err)
+			}
+		}
+		cleanupAppender(b, c, db, con, a)
+	}
+}
+
+func BenchmarkAppenderSingle(b *testing.B) {
+	b.Run("int8", benchmarkAppenderSingle[int8](0))
+}
+
+func BenchmarkAppenderRowSingle(b *testing.B) {
+	b.Run("int8", benchmarkAppenderRowSingle[int8](0))
+}
+
+func BenchmarkAppenderParallelRowSingle(b *testing.B) {
+	b.Run("int8", benchmarkAppenderParallelRowSingle[int8](0))
+}
+
+func BenchmarkAppenderChunkSingle(b *testing.B) {
+	b.Run("int8", benchmarkAppenderChunkSingle[int8](0))
+}
+
+func BenchmarkAppenderParallelChunkSingle(b *testing.B) {
+	b.Run("int8", benchmarkAppenderParallelChunkSingle[int8](0))
+}
+
+const createSingleTableSQL = `
+	CREATE TABLE test (
+		nested_int_list %s,
+	)
+`

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -4,6 +4,7 @@ import "C"
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/duckdb/duckdb-go/v2/mapping"
 )
@@ -23,9 +24,9 @@ type DataChunk struct {
 }
 
 // GetDataChunkCapacity returns the capacity of a data chunk.
-func GetDataChunkCapacity() int {
+var GetDataChunkCapacity = sync.OnceValue(func() int {
 	return int(mapping.VectorSize())
-}
+})
 
 // GetSize returns the internal size of the data chunk.
 func (chunk *DataChunk) GetSize() int {

--- a/table_udf_test.go
+++ b/table_udf_test.go
@@ -406,7 +406,6 @@ func (udf *parallelIncTableUDF) FillRow(localState any, row Row) (bool, error) {
 		udf.claimed += remaining
 		udf.lock.Unlock()
 	}
-
 	state.start++
 	err := SetRowValue(row, 0, state.start)
 	return true, err
@@ -465,7 +464,7 @@ func (udf *parallelChunkIncTableUDF) FillChunk(localState any, chunk DataChunk) 
 	if remaining <= 0 {
 		// No more work.
 		udf.lock.Unlock()
-		return nil
+		return chunk.SetSize(int(remaining))
 	} else if remaining >= 2048 {
 		remaining = 2048
 	}
@@ -777,7 +776,7 @@ func (udf *chunkIncTableUDF) FillChunk(chunk DataChunk) error {
 			return err
 		}
 		udf.count++
-		err := chunk.SetValue(0, i, udf.count)
+		err := SetChunkValue(chunk, 0, i, udf.count)
 		if err != nil {
 			return err
 		}

--- a/table_udf_test.go
+++ b/table_udf_test.go
@@ -75,6 +75,7 @@ type (
 	chunkIncTableUDF struct {
 		n     int64
 		count int64
+		err   error // return this when done. Could be nil
 	}
 
 	unionTableUDF struct {
@@ -309,8 +310,10 @@ var (
 )
 
 var (
-	typeBigintTableUDF, _ = NewTypeInfo(TYPE_BIGINT)
-	typeStructTableUDF    = makeStructTableUDF()
+	typeBigintTableUDF, _   = NewTypeInfo(TYPE_BIGINT)
+	typeUTinyintTableUDF, _ = NewTypeInfo(TYPE_UTINYINT)
+
+	typeStructTableUDF = makeStructTableUDF()
 )
 
 func makeStructTableUDF() TypeInfo {
@@ -773,7 +776,10 @@ func (udf *chunkIncTableUDF) FillChunk(chunk DataChunk) error {
 	for ; i < size; i++ {
 		if udf.count >= udf.n {
 			err := chunk.SetSize(i)
-			return err
+			if err != nil {
+				return err
+			}
+			return udf.err
 		}
 		udf.count++
 		err := SetChunkValue(chunk, 0, i, udf.count)

--- a/vector_setters.go
+++ b/vector_setters.go
@@ -495,11 +495,6 @@ func setUnion[S any](vec *vector, rowIdx mapping.IdxT, val S) error {
 
 //nolint:gocyclo
 func setVectorVal[S any](vec *vector, rowIdx mapping.IdxT, val S) error {
-	name, inMap := unsupportedValueTypeToStringMap[vec.Type]
-	if inMap {
-		return unsupportedTypeError(name)
-	}
-
 	switch vec.Type {
 	case TYPE_BOOLEAN:
 		return setBool(vec, rowIdx, val)
@@ -561,6 +556,11 @@ func setVectorVal[S any](vec *vector, rowIdx mapping.IdxT, val S) error {
 	case TYPE_UNION:
 		return setUnion(vec, rowIdx, val)
 	default:
+		name, inMap := unsupportedValueTypeToStringMap[vec.Type]
+		if inMap {
+			return unsupportedTypeError(name)
+		}
+
 		return unsupportedTypeError(unknownTypeErrMsg)
 	}
 }


### PR DESCRIPTION
This currently also includes the changes of https://github.com/marcboeker/go-duckdb/pull/483, but I will rebase once that is merged.

This adds multiple ways to append, using all the variations of table sources.
Using just row-based is actually slower than the current solution, which may be expected as it operates very similarly but with extra steps. The real performance gains come from the parallel implementations.
The benchmarks don't show much improvement (~25% for both parallel row and parallel chunk), however this is due to the fact that they are both bottlenecked on appending the chunks in DuckDB itself. If instead the bottleneck would be the data ingestion/computation on the user-side (instead of a simple counter), this would be much more favorable to the parallel variations. Currently they barely show up as parallel on my laptop.

Another improvement would be setting entire vectors of data at a time, instead of individual values, this could be done in a future PR.