### PR TITLE
Generalize `getValue`

### DIFF
--- a/table_udf.go
+++ b/table_udf.go
@@ -174,10 +174,10 @@ func udfBindTyped[T tableSource](infoPtr unsafe.Pointer) {
 	args := make([]any, argCount)
 	namedArgs := make(map[string]any)
 
-	for i, t := range config.Arguments {
+	for i := range config.Arguments {
 		var err error
 		value := mapping.BindGetParameter(info, mapping.IdxT(i))
-		args[i], err = getValue(t, value)
+		args[i], err = getValue(value)
 		mapping.DestroyValue(&value)
 
 		if err != nil {
@@ -186,10 +186,10 @@ func udfBindTyped[T tableSource](infoPtr unsafe.Pointer) {
 		}
 	}
 
-	for name, t := range config.NamedArguments {
+	for name := range config.NamedArguments {
 		var err error
 		value := mapping.BindGetNamedParameter(info, name)
-		namedArgs[name], err = getValue(t, value)
+		namedArgs[name], err = getValue(value)
 		mapping.DestroyValue(&value)
 
 		if err != nil {

--- a/value.go
+++ b/value.go
@@ -9,8 +9,11 @@ import (
 	"github.com/duckdb/duckdb-go/mapping"
 )
 
-func getValue(info TypeInfo, v mapping.Value) (any, error) {
-	t := info.InternalType()
+func getValue(v mapping.Value) (any, error) {
+	// The logical type is valid as long as v (mapping.Value) is valid,
+	// i.e., it must not be destroyed.
+	lt := mapping.GetValueType(v)
+	t := mapping.GetTypeId(lt)
 	switch t {
 	case TYPE_BOOLEAN:
 		return mapping.GetBool(v), nil


### PR DESCRIPTION
Minor enhancement so that we don't need `TypeInfo` to get the "Go" type from a `duckdb_value` (`mapping.Value`).