### PR TITLE
Preserve the timezone of TIMETZ

### DIFF
--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -611,7 +611,7 @@ func TestTypeNamesAndScanTypes(t *testing.T) {
 		// DUCKDB_TYPE_TIME_TZ
 		{
 			sql:      `SELECT '11:30:00+03'::TIMETZ AS col`,
-			value:    time.Date(1, time.January, 1, 8, 30, 0, 0, time.UTC),
+			value:    time.Date(1, time.January, 1, 11, 30, 0, 0, time.FixedZone("", 3*3600)),
 			typeName: "TIMETZ",
 		},
 		// DUCKDB_TYPE_TIMESTAMP_TZ

--- a/statement.go
+++ b/statement.go
@@ -248,8 +248,10 @@ func (s *Stmt) bindTime(val driver.NamedValue, t Type, n int) (mapping.State, er
 		return state, nil
 	}
 
-	// TYPE_TIME_TZ: The UTC offset is 0.
-	ti := mapping.CreateTimeTZ(ticks, 0)
+	// TYPE_TIME_TZ: Preserve the UTC offset from the input time.
+	goTime, _ := castToTime(val.Value)
+	_, offset := goTime.Zone()
+	ti := mapping.CreateTimeTZ(ticks, int32(offset))
 	v := mapping.CreateTimeTZValue(ti)
 	state := mapping.BindValue(*s.preparedStmt, mapping.IdxT(n+1), v)
 	mapping.DestroyValue(&v)

--- a/type_info_test.go
+++ b/type_info_test.go
@@ -42,7 +42,7 @@ var testPrimitiveSQLValues = map[Type]testTypeValues{
 	TYPE_TIMESTAMP_MS: {input: `TIMESTAMP_MS '1992-09-20 11:30:00.123'`, output: `1992-09-20 11:30:00.123 +0000 UTC`},
 	TYPE_TIMESTAMP_NS: {input: `TIMESTAMP_NS '1992-09-20 11:30:00.123456789'`, output: `1992-09-20 11:30:00.123456789 +0000 UTC`},
 	TYPE_UUID:         {input: `uuid()`, output: ``},
-	TYPE_TIME_TZ:      {input: `'11:30:00.123456+06'::TIMETZ`, output: `0001-01-01 05:30:00.123456 +0000 UTC`},
+	TYPE_TIME_TZ:      {input: `'11:30:00.123456+06'::TIMETZ`, output: `0001-01-01 11:30:00.123456 +0600 +0600`},
 	TYPE_TIMESTAMP_TZ: {input: `TIMESTAMPTZ '1992-09-20 11:30:00.123456+04'`, output: `1992-09-20 07:30:00.123456 +0000 UTC`},
 }
 

--- a/vector_getters.go
+++ b/vector_getters.go
@@ -102,8 +102,11 @@ func getTimeTZ(ti *mapping.TimeTZ) time.Time {
 	// TIMETZ has microsecond precision.
 	hour, minute, sec, micro := mapping.TimeStructMembers(&timeStruct)
 	nanos := int(micro) * 1000
-	loc := time.FixedZone("", int(offset))
-	return time.Date(1, time.January, 1, int(hour), int(minute), int(sec), nanos, loc).UTC()
+	loc := time.UTC
+	if offset != 0 {
+		loc = time.FixedZone("", int(offset))
+	}
+	return time.Date(1, time.January, 1, int(hour), int(minute), int(sec), nanos, loc)
 }
 
 func (vec *vector) getInterval(rowIdx mapping.IdxT) Interval {

--- a/vector_setters.go
+++ b/vector_setters.go
@@ -136,7 +136,6 @@ func setTime[S any](vec *vector, rowIdx mapping.IdxT, val S) error {
 		}
 		setPrimitive(vec, rowIdx, ti)
 	case TYPE_TIME_TZ:
-		// The UTC offset is 0.
 		ti, err := inferTimeTZ(val)
 		if err != nil {
 			return err


### PR DESCRIPTION
The TIMETZ type stores both a time and a timezone offset. But when reading this type it's impossible to get the associated timezone, because it would always be set to UTC. This changes the code to start preserving it, so it can be used.
