### PR TITLE
Update copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Copyright 2019 Marc Boeker
+Copyright 2019-2024 Marc Boeker
+Copyright 2025-2026 Stichting DuckDB Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
Preserve Marc's original copyright (active 2019-2024) and add DuckDB Foundation copyright following the Oct 2025 takeover.