### PR TITLE
Add scalar udf chunk api

### DIFF
--- a/data_chunk.go
+++ b/data_chunk.go
@@ -33,6 +33,11 @@ func (chunk *DataChunk) GetSize() int {
 	return chunk.size
 }
 
+// ColumnCount returns the number of columns in the data chunk.
+func (chunk *DataChunk) ColumnCount() int {
+	return len(chunk.columns)
+}
+
 // SetSize sets the internal size of the data chunk. Cannot exceed GetCapacity().
 func (chunk *DataChunk) SetSize(size int) error {
 	if size > GetDataChunkCapacity() {

--- a/examples/scalar_udf/main.go
+++ b/examples/scalar_udf/main.go
@@ -172,7 +172,7 @@ func (*chunkSum) Config() duckdb.ScalarFuncConfig {
 func (*chunkSum) Executor() duckdb.ScalarFuncExecutor {
 	return duckdb.ScalarFuncExecutor{
 		ChunkContextExecutor: func(ctx context.Context, chunk *duckdb.ScalarUDFChunk) error {
-			for row, _ := range chunk.Rows() {
+			for row := range chunk.Rows() {
 				// row.Args contains pre-fetched input values.
 				// NULL rows are automatically skipped and their result set to NULL
 				// (when SpecialNullHandling is false, which is the default).
@@ -203,7 +203,10 @@ func chunkSumScalarUDF() {
 
 	rows, err := db.Query(`SELECT chunk_sum(a, b) FROM test_chunk`)
 	check(err)
-	defer rows.Close()
+	defer func() {
+		err := rows.Close()
+		check(err)
+	}()
 
 	count := 0
 	for rows.Next() {

--- a/examples/scalar_udf/main.go
+++ b/examples/scalar_udf/main.go
@@ -172,16 +172,14 @@ func (*chunkSum) Config() duckdb.ScalarFuncConfig {
 func (*chunkSum) Executor() duckdb.ScalarFuncExecutor {
 	return duckdb.ScalarFuncExecutor{
 		ChunkContextExecutor: func(ctx context.Context, chunk *duckdb.ScalarUDFChunk) error {
-			for row := range chunk.Rows() {
-				// row.Args contains pre-fetched input values.
-				// NULL rows are automatically skipped and their result set to NULL
-				// (when SpecialNullHandling is false, which is the default).
+			rows, onFinish := chunk.Rows()
+			for row := range rows {
 				result := row.Args[0].(int32) + row.Args[1].(int32)
 				if err := row.SetResult(result); err != nil {
 					return err
 				}
 			}
-			return nil
+			return onFinish()
 		},
 	}
 }

--- a/scalar_udf.go
+++ b/scalar_udf.go
@@ -70,8 +70,8 @@ type (
 	// It takes a context and the row values, and returns the row execution result, or error.
 	RowContextExecutorFn func(ctx context.Context, values []driver.Value) (any, error)
 	// ChunkContextExecutorFn accepts a chunk-based execution function.
-	// It receives a ScalarUDFChunk providing lazy row-oriented access to inputs
-	// and direct writes to output. The user must call SetResult for each row.
+	// It receives a ScalarUDFChunk providing row-oriented access to inputs
+	// and direct writes to output. The user must call row.SetResult for each row.
 	ChunkContextExecutorFn func(ctx context.Context, chunk *ScalarUDFChunk) error
 	// ScalarBinderFn takes a context and the scalar function's arguments.
 	// It returns the updated context, which can now contain arbitrary data available during execution.

--- a/scalar_udf.go
+++ b/scalar_udf.go
@@ -70,9 +70,9 @@ type (
 	// It takes a context and the row values, and returns the row execution result, or error.
 	RowContextExecutorFn func(ctx context.Context, values []driver.Value) (any, error)
 	// ChunkContextExecutorFn accepts a chunk-based execution function.
-	// It receives a ScalarFuncChunk providing lazy row-oriented access to inputs
+	// It receives a ScalarUDFChunk providing lazy row-oriented access to inputs
 	// and direct writes to output. The user must call SetResult for each row.
-	ChunkContextExecutorFn func(ctx context.Context, chunk *ScalarFuncChunk) error
+	ChunkContextExecutorFn func(ctx context.Context, chunk *ScalarUDFChunk) error
 	// ScalarBinderFn takes a context and the scalar function's arguments.
 	// It returns the updated context, which can now contain arbitrary data available during execution.
 	ScalarBinderFn func(ctx context.Context, args []ScalarUDFArg) (context.Context, error)
@@ -274,7 +274,7 @@ func executeChunk(funcCtx *scalarFuncContext, bindInfo *bindData,
 	ctx := funcCtx.ctxStore.load(bindInfo.connId)
 
 	// Create lazy chunk wrapper - no data copied yet.
-	chunk := &ScalarFuncChunk{
+	chunk := &ScalarUDFChunk{
 		input:         inputChunk,
 		output:        outputChunk,
 		nullInNullOut: nullInNullOut,

--- a/scalar_udf.go
+++ b/scalar_udf.go
@@ -268,8 +268,8 @@ func scalar_udf_callback(functionInfoPtr, inputPtr, outputPtr unsafe.Pointer) {
 // executeChunk handles chunk-based execution of scalar UDFs.
 func executeChunk(funcCtx *scalarFuncContext, bindInfo *bindData,
 	inputChunk, outputChunk *DataChunk,
-	functionInfo mapping.FunctionInfo, nullInNullOut bool) {
-
+	functionInfo mapping.FunctionInfo, nullInNullOut bool,
+) {
 	// Get context.
 	ctx := funcCtx.ctxStore.load(bindInfo.connId)
 

--- a/scalar_udf_chunk.go
+++ b/scalar_udf_chunk.go
@@ -24,7 +24,15 @@ type ScalarUDFChunk struct {
 	input         chunkReader
 	output        chunkWriter
 	nullInNullOut bool
-	nullRows      []bool // lazily populated when nullInNullOut is true
+}
+
+// ScalarUDFRow represents a single row in a ScalarUDFChunk.
+// It provides access to input values and allows setting the result.
+type ScalarUDFRow struct {
+	chunk  *ScalarUDFChunk
+	rowIdx int
+	// Args contains the pre-fetched input values for this row.
+	Args []driver.Value
 }
 
 // RowCount returns the number of rows in this chunk.
@@ -40,97 +48,66 @@ func (c *ScalarUDFChunk) ColumnCount() int {
 // Rows returns an iterator over all rows in the chunk.
 // Each iteration yields a ScalarUDFRow and its index.
 //
+// When nullInNullOut is enabled (the default), rows containing any NULL input
+// are automatically skipped and their result is set to NULL. This means your
+// UDF only sees rows with all non-NULL inputs.
+//
 // Example:
 //
 //	for row, rowIdx := range chunk.Rows() {
-//	    values := row.Values()
-//	    // process values...
+//	    // row.Args contains the pre-fetched input values
+//	    result := row.Args[0].(int32) + row.Args[1].(int32)
 //	    row.SetResult(result)
 //	}
 func (c *ScalarUDFChunk) Rows() iter.Seq2[*ScalarUDFRow, int] {
 	return func(yield func(*ScalarUDFRow, int) bool) {
-		for i := range c.RowCount() {
-			row := &ScalarUDFRow{chunk: c, rowIdx: i}
-			if !yield(row, i) {
+		colCount := c.ColumnCount()
+
+		for rowIdx := range c.RowCount() {
+			// Pre-fetch all values for this row
+			args := make([]driver.Value, colCount)
+			hasNull := false
+
+			for colIdx := range colCount {
+				val, err := c.input.GetValue(colIdx, rowIdx)
+				if err != nil {
+					// On error, we can't continue - but iterators can't return errors.
+					// The error will surface when the user tries to use the row.
+					// For now, yield the row with what we have.
+					break
+				}
+				args[colIdx] = val
+
+				if c.nullInNullOut && val == nil {
+					hasNull = true
+				}
+			}
+
+			// If nullInNullOut and row has NULL, auto-set result to NULL and skip
+			if c.nullInNullOut && hasNull {
+				_ = c.output.SetValue(0, rowIdx, nil)
+				continue
+			}
+
+			row := &ScalarUDFRow{
+				chunk:  c,
+				rowIdx: rowIdx,
+				Args:   args,
+			}
+
+			if !yield(row, rowIdx) {
 				return
 			}
 		}
 	}
 }
 
-// ScalarUDFRow represents a single row in a ScalarUDFChunk.
-// It provides access to input values and allows setting the result.
-type ScalarUDFRow struct {
-	chunk  *ScalarUDFChunk
-	rowIdx int
-}
-
-
-// Values returns all input column values for this row.
-// Values are read lazily from DuckDB's vector memory.
-func (r *ScalarUDFRow) Values() ([]driver.Value, error) {
-	colCount := r.chunk.ColumnCount()
-	values := make([]driver.Value, colCount)
-	for colIdx := range colCount {
-		val, err := r.chunk.input.GetValue(colIdx, r.rowIdx)
-		if err != nil {
-			return nil, err
-		}
-		values[colIdx] = val
-	}
-	return values, nil
-}
-
-// Value returns a single input column value for this row.
-func (r *ScalarUDFRow) Value(colIdx int) (driver.Value, error) {
-	return r.chunk.input.GetValue(colIdx, r.rowIdx)
-}
-
 // SetResult writes the result value for this row directly to the output vector.
-// If nullInNullOut is enabled and any input in the row was NULL,
-// the result is automatically set to NULL regardless of val.
 func (r *ScalarUDFRow) SetResult(val any) error {
-	if r.chunk.nullInNullOut && r.chunk.nullRows != nil && r.chunk.nullRows[r.rowIdx] {
-		return r.chunk.output.SetValue(0, r.rowIdx, nil)
-	}
 	return r.chunk.output.SetValue(0, r.rowIdx, val)
-}
-
-// IsNull returns true if any input column in this row is NULL.
-// Only meaningful when SpecialNullHandling is false (default).
-func (r *ScalarUDFRow) IsNull() bool {
-	if !r.chunk.nullInNullOut {
-		return false
-	}
-	if r.chunk.nullRows == nil {
-		return false
-	}
-	return r.chunk.nullRows[r.rowIdx]
 }
 
 // Index returns the row index within the chunk.
 func (r *ScalarUDFRow) Index() int {
 	return r.rowIdx
-}
-
-// checkRowNulls pre-scans a row for NULL values (for null-in-null-out handling).
-// Called internally before user execution when SpecialNullHandling is false.
-func (c *ScalarUDFChunk) checkRowNulls(rowIdx int) error {
-	if !c.nullInNullOut {
-		return nil
-	}
-	if c.nullRows == nil {
-		c.nullRows = make([]bool, c.RowCount())
-	}
-	for colIdx := range c.ColumnCount() {
-		val, err := c.input.GetValue(colIdx, rowIdx)
-		if err != nil {
-			return err
-		}
-		if val == nil {
-			c.nullRows[rowIdx] = true
-			return nil
-		}
-	}
-	return nil
 }

--- a/scalar_udf_chunk.go
+++ b/scalar_udf_chunk.go
@@ -1,0 +1,74 @@
+package duckdb
+
+import "database/sql/driver"
+
+// ScalarFuncChunk provides lazy, row-oriented access to UDF input/output.
+// Values are read on-demand from the underlying DuckDB vectors - no pre-materialization.
+// Results are written directly to the output vector - no intermediate storage.
+type ScalarFuncChunk struct {
+	input         *DataChunk
+	output        *DataChunk
+	nullInNullOut bool
+	nullRows      []bool // lazily populated when nullInNullOut is true
+}
+
+// RowCount returns the number of rows in this chunk.
+func (c *ScalarFuncChunk) RowCount() int {
+	return c.input.GetSize()
+}
+
+// ColumnCount returns the number of input columns.
+func (c *ScalarFuncChunk) ColumnCount() int {
+	return len(c.input.columns)
+}
+
+// GetValue reads a single value lazily from the input chunk.
+// This goes directly to DuckDB's vector memory - no intermediate copy.
+func (c *ScalarFuncChunk) GetValue(rowIdx, colIdx int) (driver.Value, error) {
+	return c.input.GetValue(colIdx, rowIdx)
+}
+
+// SetResult writes a result value directly to the output vector.
+// If nullInNullOut is enabled and any input in the row was NULL,
+// the result is automatically set to NULL regardless of val.
+func (c *ScalarFuncChunk) SetResult(rowIdx int, val any) error {
+	if c.nullInNullOut && c.nullRows != nil && c.nullRows[rowIdx] {
+		return c.output.SetValue(0, rowIdx, nil)
+	}
+	return c.output.SetValue(0, rowIdx, val)
+}
+
+// IsRowNull returns true if any input column in this row is NULL.
+// Only meaningful when SpecialNullHandling is false (default).
+// This is lazily computed on first access.
+func (c *ScalarFuncChunk) IsRowNull(rowIdx int) bool {
+	if !c.nullInNullOut {
+		return false
+	}
+	if c.nullRows == nil {
+		return false // Not tracked
+	}
+	return c.nullRows[rowIdx]
+}
+
+// checkRowNulls pre-scans a row for NULL values (for null-in-null-out handling).
+// Called internally before user execution when SpecialNullHandling is false.
+func (c *ScalarFuncChunk) checkRowNulls(rowIdx int) error {
+	if !c.nullInNullOut {
+		return nil
+	}
+	if c.nullRows == nil {
+		c.nullRows = make([]bool, c.RowCount())
+	}
+	for colIdx := range c.ColumnCount() {
+		val, err := c.input.GetValue(colIdx, rowIdx)
+		if err != nil {
+			return err
+		}
+		if val == nil {
+			c.nullRows[rowIdx] = true
+			return nil
+		}
+	}
+	return nil
+}

--- a/scalar_udf_chunk.go
+++ b/scalar_udf_chunk.go
@@ -1,59 +1,121 @@
 package duckdb
 
-import "database/sql/driver"
+import (
+	"database/sql/driver"
+	"iter"
+)
 
-// ScalarFuncChunk provides lazy, row-oriented access to UDF input/output.
+// chunkReader is the interface for reading from a data chunk.
+type chunkReader interface {
+	GetSize() int
+	ColumnCount() int
+	GetValue(colIdx, rowIdx int) (any, error)
+}
+
+// chunkWriter is the interface for writing to a data chunk.
+type chunkWriter interface {
+	SetValue(colIdx, rowIdx int, val any) error
+}
+
+// ScalarUDFChunk provides lazy, row-oriented access to UDF input/output.
 // Values are read on-demand from the underlying DuckDB vectors - no pre-materialization.
 // Results are written directly to the output vector - no intermediate storage.
-type ScalarFuncChunk struct {
-	input         *DataChunk
-	output        *DataChunk
+type ScalarUDFChunk struct {
+	input         chunkReader
+	output        chunkWriter
 	nullInNullOut bool
 	nullRows      []bool // lazily populated when nullInNullOut is true
 }
 
 // RowCount returns the number of rows in this chunk.
-func (c *ScalarFuncChunk) RowCount() int {
+func (c *ScalarUDFChunk) RowCount() int {
 	return c.input.GetSize()
 }
 
 // ColumnCount returns the number of input columns.
-func (c *ScalarFuncChunk) ColumnCount() int {
-	return len(c.input.columns)
+func (c *ScalarUDFChunk) ColumnCount() int {
+	return c.input.ColumnCount()
 }
 
-// GetValue reads a single value lazily from the input chunk.
-// This goes directly to DuckDB's vector memory - no intermediate copy.
-func (c *ScalarFuncChunk) GetValue(rowIdx, colIdx int) (driver.Value, error) {
-	return c.input.GetValue(colIdx, rowIdx)
+// Rows returns an iterator over all rows in the chunk.
+// Each iteration yields a ScalarUDFRow and its index.
+//
+// Example:
+//
+//	for row, rowIdx := range chunk.Rows() {
+//	    values := row.Values()
+//	    // process values...
+//	    row.SetResult(result)
+//	}
+func (c *ScalarUDFChunk) Rows() iter.Seq2[*ScalarUDFRow, int] {
+	return func(yield func(*ScalarUDFRow, int) bool) {
+		for i := range c.RowCount() {
+			row := &ScalarUDFRow{chunk: c, rowIdx: i}
+			if !yield(row, i) {
+				return
+			}
+		}
+	}
 }
 
-// SetResult writes a result value directly to the output vector.
+// ScalarUDFRow represents a single row in a ScalarUDFChunk.
+// It provides access to input values and allows setting the result.
+type ScalarUDFRow struct {
+	chunk  *ScalarUDFChunk
+	rowIdx int
+}
+
+
+// Values returns all input column values for this row.
+// Values are read lazily from DuckDB's vector memory.
+func (r *ScalarUDFRow) Values() ([]driver.Value, error) {
+	colCount := r.chunk.ColumnCount()
+	values := make([]driver.Value, colCount)
+	for colIdx := range colCount {
+		val, err := r.chunk.input.GetValue(colIdx, r.rowIdx)
+		if err != nil {
+			return nil, err
+		}
+		values[colIdx] = val
+	}
+	return values, nil
+}
+
+// Value returns a single input column value for this row.
+func (r *ScalarUDFRow) Value(colIdx int) (driver.Value, error) {
+	return r.chunk.input.GetValue(colIdx, r.rowIdx)
+}
+
+// SetResult writes the result value for this row directly to the output vector.
 // If nullInNullOut is enabled and any input in the row was NULL,
 // the result is automatically set to NULL regardless of val.
-func (c *ScalarFuncChunk) SetResult(rowIdx int, val any) error {
-	if c.nullInNullOut && c.nullRows != nil && c.nullRows[rowIdx] {
-		return c.output.SetValue(0, rowIdx, nil)
+func (r *ScalarUDFRow) SetResult(val any) error {
+	if r.chunk.nullInNullOut && r.chunk.nullRows != nil && r.chunk.nullRows[r.rowIdx] {
+		return r.chunk.output.SetValue(0, r.rowIdx, nil)
 	}
-	return c.output.SetValue(0, rowIdx, val)
+	return r.chunk.output.SetValue(0, r.rowIdx, val)
 }
 
-// IsRowNull returns true if any input column in this row is NULL.
+// IsNull returns true if any input column in this row is NULL.
 // Only meaningful when SpecialNullHandling is false (default).
-// This is lazily computed on first access.
-func (c *ScalarFuncChunk) IsRowNull(rowIdx int) bool {
-	if !c.nullInNullOut {
+func (r *ScalarUDFRow) IsNull() bool {
+	if !r.chunk.nullInNullOut {
 		return false
 	}
-	if c.nullRows == nil {
-		return false // Not tracked
+	if r.chunk.nullRows == nil {
+		return false
 	}
-	return c.nullRows[rowIdx]
+	return r.chunk.nullRows[r.rowIdx]
+}
+
+// Index returns the row index within the chunk.
+func (r *ScalarUDFRow) Index() int {
+	return r.rowIdx
 }
 
 // checkRowNulls pre-scans a row for NULL values (for null-in-null-out handling).
 // Called internally before user execution when SpecialNullHandling is false.
-func (c *ScalarFuncChunk) checkRowNulls(rowIdx int) error {
+func (c *ScalarUDFChunk) checkRowNulls(rowIdx int) error {
 	if !c.nullInNullOut {
 		return nil
 	}

--- a/scalar_udf_chunk_test.go
+++ b/scalar_udf_chunk_test.go
@@ -1,0 +1,479 @@
+package duckdb
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mockChunkReader is a mock implementation of chunkReader for testing.
+type mockChunkReader struct {
+	rows     [][]any
+	errOnGet error
+}
+
+func (m *mockChunkReader) GetSize() int {
+	return len(m.rows)
+}
+
+func (m *mockChunkReader) ColumnCount() int {
+	if len(m.rows) == 0 {
+		return 0
+	}
+	return len(m.rows[0])
+}
+
+func (m *mockChunkReader) GetValue(colIdx, rowIdx int) (any, error) {
+	if m.errOnGet != nil {
+		return nil, m.errOnGet
+	}
+	if rowIdx < 0 || rowIdx >= len(m.rows) {
+		return nil, errors.New("row index out of bounds")
+	}
+	if colIdx < 0 || colIdx >= len(m.rows[rowIdx]) {
+		return nil, errors.New("column index out of bounds")
+	}
+	return m.rows[rowIdx][colIdx], nil
+}
+
+// mockChunkWriter is a mock implementation of chunkWriter for testing.
+type mockChunkWriter struct {
+	results  map[int]any
+	errOnSet error
+}
+
+func newMockChunkWriter() *mockChunkWriter {
+	return &mockChunkWriter{results: make(map[int]any)}
+}
+
+func (m *mockChunkWriter) SetValue(colIdx, rowIdx int, val any) error {
+	if m.errOnSet != nil {
+		return m.errOnSet
+	}
+	m.results[rowIdx] = val
+	return nil
+}
+
+func TestScalarUDFChunk_RowCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		rows     [][]any
+		expected int
+	}{
+		{"empty", [][]any{}, 0},
+		{"single row", [][]any{{1, 2}}, 1},
+		{"multiple rows", [][]any{{1, 2}, {3, 4}, {5, 6}}, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunk := &ScalarUDFChunk{
+				input: &mockChunkReader{rows: tt.rows},
+			}
+			require.Equal(t, tt.expected, chunk.RowCount())
+		})
+	}
+}
+
+func TestScalarUDFChunk_ColumnCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		rows     [][]any
+		expected int
+	}{
+		{"empty", [][]any{}, 0},
+		{"single column", [][]any{{1}}, 1},
+		{"two columns", [][]any{{1, 2}}, 2},
+		{"three columns", [][]any{{1, 2, 3}}, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunk := &ScalarUDFChunk{
+				input: &mockChunkReader{rows: tt.rows},
+			}
+			require.Equal(t, tt.expected, chunk.ColumnCount())
+		})
+	}
+}
+
+func TestScalarUDFChunk_Rows(t *testing.T) {
+	input := &mockChunkReader{
+		rows: [][]any{
+			{int32(1), int32(10)},
+			{int32(2), int32(20)},
+			{int32(3), int32(30)},
+		},
+	}
+	output := newMockChunkWriter()
+
+	chunk := &ScalarUDFChunk{
+		input:  input,
+		output: output,
+	}
+
+	// Test iteration
+	count := 0
+	for row, idx := range chunk.Rows() {
+		require.Equal(t, count, idx)
+		require.Equal(t, count, row.Index())
+		count++
+	}
+	require.Equal(t, 3, count)
+}
+
+func TestScalarUDFChunk_RowsEarlyBreak(t *testing.T) {
+	input := &mockChunkReader{
+		rows: [][]any{
+			{int32(1)},
+			{int32(2)},
+			{int32(3)},
+		},
+	}
+
+	chunk := &ScalarUDFChunk{
+		input:  input,
+		output: newMockChunkWriter(),
+	}
+
+	// Test early break
+	count := 0
+	for _, _ = range chunk.Rows() {
+		count++
+		if count == 2 {
+			break
+		}
+	}
+	require.Equal(t, 2, count)
+}
+
+func TestScalarUDFRow_Values(t *testing.T) {
+	input := &mockChunkReader{
+		rows: [][]any{
+			{int32(1), "hello", 3.14},
+			{int32(2), "world", 2.71},
+		},
+	}
+
+	chunk := &ScalarUDFChunk{
+		input:  input,
+		output: newMockChunkWriter(),
+	}
+
+	for row, idx := range chunk.Rows() {
+		values, err := row.Values()
+		require.NoError(t, err)
+		require.Len(t, values, len(input.rows[idx]))
+		for i, v := range values {
+			require.Equal(t, input.rows[idx][i], v)
+		}
+	}
+}
+
+func TestScalarUDFRow_ValuesError(t *testing.T) {
+	expectedErr := errors.New("test error")
+	input := &mockChunkReader{
+		rows:     [][]any{{1, 2}},
+		errOnGet: expectedErr,
+	}
+
+	chunk := &ScalarUDFChunk{
+		input:  input,
+		output: newMockChunkWriter(),
+	}
+
+	for row, _ := range chunk.Rows() {
+		_, err := row.Values()
+		require.ErrorIs(t, err, expectedErr)
+	}
+}
+
+func TestScalarUDFRow_Value(t *testing.T) {
+	input := &mockChunkReader{
+		rows: [][]any{
+			{int32(1), "hello", 3.14},
+		},
+	}
+
+	chunk := &ScalarUDFChunk{
+		input:  input,
+		output: newMockChunkWriter(),
+	}
+
+	for row, _ := range chunk.Rows() {
+		val0, err := row.Value(0)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), val0)
+
+		val1, err := row.Value(1)
+		require.NoError(t, err)
+		require.Equal(t, "hello", val1)
+
+		val2, err := row.Value(2)
+		require.NoError(t, err)
+		require.Equal(t, 3.14, val2)
+	}
+}
+
+func TestScalarUDFRow_SetResult(t *testing.T) {
+	input := &mockChunkReader{
+		rows: [][]any{{1}, {2}, {3}},
+	}
+	output := newMockChunkWriter()
+
+	chunk := &ScalarUDFChunk{
+		input:  input,
+		output: output,
+	}
+
+	for row, idx := range chunk.Rows() {
+		err := row.SetResult(idx * 10)
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, 0, output.results[0])
+	require.Equal(t, 10, output.results[1])
+	require.Equal(t, 20, output.results[2])
+}
+
+func TestScalarUDFRow_SetResultError(t *testing.T) {
+	expectedErr := errors.New("write error")
+	input := &mockChunkReader{
+		rows: [][]any{{1}},
+	}
+	output := &mockChunkWriter{
+		results:  make(map[int]any),
+		errOnSet: expectedErr,
+	}
+
+	chunk := &ScalarUDFChunk{
+		input:  input,
+		output: output,
+	}
+
+	for row, _ := range chunk.Rows() {
+		err := row.SetResult(42)
+		require.ErrorIs(t, err, expectedErr)
+	}
+}
+
+func TestScalarUDFRow_IsNull_NullInNullOutDisabled(t *testing.T) {
+	input := &mockChunkReader{
+		rows: [][]any{{nil}},
+	}
+
+	chunk := &ScalarUDFChunk{
+		input:         input,
+		output:        newMockChunkWriter(),
+		nullInNullOut: false,
+	}
+
+	for row, _ := range chunk.Rows() {
+		require.False(t, row.IsNull())
+	}
+}
+
+func TestScalarUDFRow_IsNull_NullInNullOutEnabled(t *testing.T) {
+	input := &mockChunkReader{
+		rows: [][]any{
+			{int32(1), int32(2)}, // no nulls
+			{nil, int32(2)},      // first column null
+			{int32(1), nil},      // second column null
+			{nil, nil},           // both null
+		},
+	}
+
+	chunk := &ScalarUDFChunk{
+		input:         input,
+		output:        newMockChunkWriter(),
+		nullInNullOut: true,
+	}
+
+	// Pre-scan for nulls
+	for rowIdx := range chunk.RowCount() {
+		err := chunk.checkRowNulls(rowIdx)
+		require.NoError(t, err)
+	}
+
+	expectedNulls := []bool{false, true, true, true}
+	idx := 0
+	for row, _ := range chunk.Rows() {
+		require.Equal(t, expectedNulls[idx], row.IsNull(), "row %d", idx)
+		idx++
+	}
+}
+
+func TestScalarUDFRow_SetResult_NullInNullOut(t *testing.T) {
+	input := &mockChunkReader{
+		rows: [][]any{
+			{int32(1), int32(2)}, // no nulls
+			{nil, int32(2)},      // has null
+		},
+	}
+	output := newMockChunkWriter()
+
+	chunk := &ScalarUDFChunk{
+		input:         input,
+		output:        output,
+		nullInNullOut: true,
+	}
+
+	// Pre-scan for nulls
+	for rowIdx := range chunk.RowCount() {
+		err := chunk.checkRowNulls(rowIdx)
+		require.NoError(t, err)
+	}
+
+	for row, _ := range chunk.Rows() {
+		// Try to set result to 42 for all rows
+		err := row.SetResult(int32(42))
+		require.NoError(t, err)
+	}
+
+	// Row 0 should have 42, row 1 should have nil (due to null-in-null-out)
+	require.Equal(t, int32(42), output.results[0])
+	require.Nil(t, output.results[1])
+}
+
+func TestScalarUDFChunk_checkRowNulls(t *testing.T) {
+	input := &mockChunkReader{
+		rows: [][]any{
+			{int32(1), int32(2)},
+			{nil, int32(2)},
+			{int32(1), nil},
+		},
+	}
+
+	chunk := &ScalarUDFChunk{
+		input:         input,
+		output:        newMockChunkWriter(),
+		nullInNullOut: true,
+	}
+
+	// Check all rows
+	for rowIdx := range chunk.RowCount() {
+		err := chunk.checkRowNulls(rowIdx)
+		require.NoError(t, err)
+	}
+
+	require.NotNil(t, chunk.nullRows)
+	require.Equal(t, false, chunk.nullRows[0])
+	require.Equal(t, true, chunk.nullRows[1])
+	require.Equal(t, true, chunk.nullRows[2])
+}
+
+func TestScalarUDFChunk_checkRowNulls_Disabled(t *testing.T) {
+	input := &mockChunkReader{
+		rows: [][]any{{nil}},
+	}
+
+	chunk := &ScalarUDFChunk{
+		input:         input,
+		output:        newMockChunkWriter(),
+		nullInNullOut: false,
+	}
+
+	err := chunk.checkRowNulls(0)
+	require.NoError(t, err)
+	require.Nil(t, chunk.nullRows) // Should not be allocated
+}
+
+func TestScalarUDFChunk_checkRowNulls_Error(t *testing.T) {
+	expectedErr := errors.New("read error")
+	input := &mockChunkReader{
+		rows:     [][]any{{1, 2}},
+		errOnGet: expectedErr,
+	}
+
+	chunk := &ScalarUDFChunk{
+		input:         input,
+		output:        newMockChunkWriter(),
+		nullInNullOut: true,
+	}
+
+	err := chunk.checkRowNulls(0)
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestScalarUDFRow_Index(t *testing.T) {
+	input := &mockChunkReader{
+		rows: [][]any{{1}, {2}, {3}, {4}, {5}},
+	}
+
+	chunk := &ScalarUDFChunk{
+		input:  input,
+		output: newMockChunkWriter(),
+	}
+
+	for row, idx := range chunk.Rows() {
+		require.Equal(t, idx, row.Index())
+	}
+}
+
+func TestScalarUDFChunk_EmptyChunk(t *testing.T) {
+	input := &mockChunkReader{rows: [][]any{}}
+	output := newMockChunkWriter()
+
+	chunk := &ScalarUDFChunk{
+		input:  input,
+		output: output,
+	}
+
+	require.Equal(t, 0, chunk.RowCount())
+	require.Equal(t, 0, chunk.ColumnCount())
+
+	// Iteration should work but yield nothing
+	count := 0
+	for _, _ = range chunk.Rows() {
+		count++
+	}
+	require.Equal(t, 0, count)
+}
+
+func TestScalarUDFChunk_Integration(t *testing.T) {
+	// Simulate a typical UDF execution pattern
+	input := &mockChunkReader{
+		rows: [][]any{
+			{int32(1), int32(10)},
+			{int32(2), int32(20)},
+			{nil, int32(30)}, // null in first column
+			{int32(4), int32(40)},
+		},
+	}
+	output := newMockChunkWriter()
+
+	chunk := &ScalarUDFChunk{
+		input:         input,
+		output:        output,
+		nullInNullOut: true,
+	}
+
+	// Pre-scan for nulls (like executeChunk does)
+	for rowIdx := range chunk.RowCount() {
+		err := chunk.checkRowNulls(rowIdx)
+		require.NoError(t, err)
+	}
+
+	// Execute UDF
+	for row, _ := range chunk.Rows() {
+		if row.IsNull() {
+			err := row.SetResult(nil)
+			require.NoError(t, err)
+			continue
+		}
+
+		values, err := row.Values()
+		require.NoError(t, err)
+
+		result := values[0].(int32) + values[1].(int32)
+		err = row.SetResult(result)
+		require.NoError(t, err)
+	}
+
+	// Verify results
+	require.Equal(t, int32(11), output.results[0])
+	require.Equal(t, int32(22), output.results[1])
+	require.Nil(t, output.results[2]) // null-in-null-out
+	require.Equal(t, int32(44), output.results[3])
+}

--- a/scalar_udf_chunk_test.go
+++ b/scalar_udf_chunk_test.go
@@ -142,7 +142,7 @@ func TestScalarUDFChunk_Rows_EarlyBreak(t *testing.T) {
 
 	// Test early break
 	count := 0
-	for _, _ = range chunk.Rows() {
+	for range chunk.Rows() {
 		count++
 		if count == 2 {
 			break
@@ -204,7 +204,7 @@ func TestScalarUDFChunk_Rows_NullInNullOut_Disabled(t *testing.T) {
 
 	// All rows should be yielded
 	count := 0
-	for _, _ = range chunk.Rows() {
+	for range chunk.Rows() {
 		count++
 	}
 
@@ -247,7 +247,7 @@ func TestScalarUDFRow_SetResultError(t *testing.T) {
 		output: output,
 	}
 
-	for row, _ := range chunk.Rows() {
+	for row := range chunk.Rows() {
 		err := row.SetResult(42)
 		require.ErrorIs(t, err, expectedErr)
 	}
@@ -282,7 +282,7 @@ func TestScalarUDFChunk_EmptyChunk(t *testing.T) {
 
 	// Iteration should work but yield nothing
 	count := 0
-	for _, _ = range chunk.Rows() {
+	for range chunk.Rows() {
 		count++
 	}
 	require.Equal(t, 0, count)
@@ -307,7 +307,7 @@ func TestScalarUDFChunk_Integration(t *testing.T) {
 	}
 
 	// Execute UDF - only non-null rows are yielded
-	for row, _ := range chunk.Rows() {
+	for row := range chunk.Rows() {
 		result := row.Args[0].(int32) + row.Args[1].(int32)
 		err := row.SetResult(result)
 		require.NoError(t, err)
@@ -332,7 +332,7 @@ func TestScalarUDFChunk_Args_TypePreservation(t *testing.T) {
 		output: newMockChunkWriter(),
 	}
 
-	for row, _ := range chunk.Rows() {
+	for row := range chunk.Rows() {
 		require.Equal(t, int32(1), row.Args[0])
 		require.Equal(t, "hello", row.Args[1])
 		require.Equal(t, 3.14, row.Args[2])
@@ -355,7 +355,7 @@ func TestScalarUDFChunk_NullInNullOut_AllNullRow(t *testing.T) {
 	}
 
 	count := 0
-	for _, _ = range chunk.Rows() {
+	for range chunk.Rows() {
 		count++
 	}
 

--- a/scalar_udf_test.go
+++ b/scalar_udf_test.go
@@ -692,3 +692,247 @@ func TestErrScalarUDFClosedConn(t *testing.T) {
 	err = RegisterScalarUDF(conn, "closed_con", errClosedConUDF)
 	require.ErrorContains(t, err, sql.ErrConnDone.Error())
 }
+
+// Chunk executor test types.
+type (
+	chunkSumSUDF          struct{}
+	chunkContextSUDF      struct{}
+	chunkNullHandlingSUDF struct{}
+	chunkErrorSUDF        struct{}
+)
+
+func (*chunkSumSUDF) Config() ScalarFuncConfig {
+	return ScalarFuncConfig{[]TypeInfo{currentInfo, currentInfo}, currentInfo, nil, false, false}
+}
+
+func (*chunkSumSUDF) Executor() ScalarFuncExecutor {
+	return ScalarFuncExecutor{
+		ChunkContextExecutor: func(ctx context.Context, chunk *ScalarFuncChunk) error {
+			for rowIdx := range chunk.RowCount() {
+				if chunk.IsRowNull(rowIdx) {
+					if err := chunk.SetResult(rowIdx, nil); err != nil {
+						return err
+					}
+					continue
+				}
+
+				a, err := chunk.GetValue(rowIdx, 0)
+				if err != nil {
+					return err
+				}
+				b, err := chunk.GetValue(rowIdx, 1)
+				if err != nil {
+					return err
+				}
+
+				result := a.(int32) + b.(int32)
+				if err := chunk.SetResult(rowIdx, result); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func (*chunkContextSUDF) Config() ScalarFuncConfig {
+	return ScalarFuncConfig{[]TypeInfo{}, currentInfo, nil, true, false}
+}
+
+func (*chunkContextSUDF) Executor() ScalarFuncExecutor {
+	return ScalarFuncExecutor{
+		ChunkContextExecutor: func(ctx context.Context, chunk *ScalarFuncChunk) error {
+			if ctx == nil {
+				return errors.New("context is nil for chunkContextSUDF")
+			}
+
+			id, ok := ctx.Value(testCtxKey).(uint64)
+			if !ok {
+				return errors.New("context does not contain the connection id for chunkContextSUDF")
+			}
+
+			for rowIdx := range chunk.RowCount() {
+				if err := chunk.SetResult(rowIdx, id); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func (*chunkNullHandlingSUDF) Config() ScalarFuncConfig {
+	// SpecialNullHandling: true means user handles NULLs manually
+	return ScalarFuncConfig{[]TypeInfo{currentInfo}, currentInfo, nil, false, true}
+}
+
+func (*chunkNullHandlingSUDF) Executor() ScalarFuncExecutor {
+	return ScalarFuncExecutor{
+		ChunkContextExecutor: func(ctx context.Context, chunk *ScalarFuncChunk) error {
+			for rowIdx := range chunk.RowCount() {
+				val, err := chunk.GetValue(rowIdx, 0)
+				if err != nil {
+					return err
+				}
+
+				// User handles NULL: return -1 for NULL inputs
+				if val == nil {
+					if err := chunk.SetResult(rowIdx, int32(-1)); err != nil {
+						return err
+					}
+				} else {
+					if err := chunk.SetResult(rowIdx, val.(int32)*2); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func (*chunkErrorSUDF) Config() ScalarFuncConfig {
+	return ScalarFuncConfig{[]TypeInfo{currentInfo}, currentInfo, nil, false, false}
+}
+
+func (*chunkErrorSUDF) Executor() ScalarFuncExecutor {
+	return ScalarFuncExecutor{
+		ChunkContextExecutor: func(ctx context.Context, chunk *ScalarFuncChunk) error {
+			return errors.New("test chunk execution error")
+		},
+	}
+}
+
+func TestChunkScalarUDF(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
+
+	var err error
+	currentInfo, err = NewTypeInfo(TYPE_INTEGER)
+	require.NoError(t, err)
+
+	var udf *chunkSumSUDF
+	err = RegisterScalarUDF(conn, "chunk_sum", udf)
+	require.NoError(t, err)
+
+	// Test with multiple rows.
+	_, err = db.Exec(`CREATE TABLE test_chunk AS SELECT i::INTEGER AS a, (i * 2)::INTEGER AS b FROM range(100) t(i)`)
+	require.NoError(t, err)
+
+	rows, err := db.Query(`SELECT a, b, chunk_sum(a, b) AS sum FROM test_chunk`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		var a, b, sum int32
+		require.NoError(t, rows.Scan(&a, &b, &sum))
+		require.Equal(t, a+b, sum)
+		count++
+	}
+	require.Equal(t, 100, count)
+}
+
+func TestChunkScalarUDFNullHandling(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
+
+	var err error
+	currentInfo, err = NewTypeInfo(TYPE_INTEGER)
+	require.NoError(t, err)
+
+	var udf *chunkSumSUDF
+	err = RegisterScalarUDF(conn, "chunk_sum", udf)
+	require.NoError(t, err)
+
+	// Test NULL in, NULL out (default behavior).
+	var sum *int
+	row := db.QueryRow(`SELECT chunk_sum(10, 42) AS sum`)
+	require.NoError(t, row.Scan(&sum))
+	require.Equal(t, 52, *sum)
+
+	row = db.QueryRow(`SELECT chunk_sum(NULL, 42) AS sum`)
+	require.NoError(t, row.Scan(&sum))
+	require.Nil(t, sum)
+
+	row = db.QueryRow(`SELECT chunk_sum(42, NULL) AS sum`)
+	require.NoError(t, row.Scan(&sum))
+	require.Nil(t, sum)
+}
+
+func TestChunkScalarUDFSpecialNullHandling(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
+
+	var err error
+	currentInfo, err = NewTypeInfo(TYPE_INTEGER)
+	require.NoError(t, err)
+
+	var udf *chunkNullHandlingSUDF
+	err = RegisterScalarUDF(conn, "chunk_null_handler", udf)
+	require.NoError(t, err)
+
+	// Test user-managed NULL handling.
+	var result int32
+	row := db.QueryRow(`SELECT chunk_null_handler(5)`)
+	require.NoError(t, row.Scan(&result))
+	require.Equal(t, int32(10), result)
+
+	row = db.QueryRow(`SELECT chunk_null_handler(NULL)`)
+	require.NoError(t, row.Scan(&result))
+	require.Equal(t, int32(-1), result)
+}
+
+func TestChunkScalarUDFContext(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
+	connId, err := ConnId(conn)
+	require.NoError(t, err)
+
+	currentInfo, err = NewTypeInfo(TYPE_UBIGINT)
+	require.NoError(t, err)
+
+	var udf *chunkContextSUDF
+	err = RegisterScalarUDF(conn, "chunk_get_conn_id", udf)
+	require.NoError(t, err)
+
+	ctx := context.WithValue(context.Background(), testCtxKey, connId)
+
+	var result uint64
+	row := conn.QueryRowContext(ctx, `SELECT chunk_get_conn_id()`)
+	require.NoError(t, row.Scan(&result))
+	require.Equal(t, connId, result)
+}
+
+func TestChunkScalarUDFError(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	conn := openConnWrapper(t, db, context.Background())
+	defer closeConnWrapper(t, conn)
+
+	var err error
+	currentInfo, err = NewTypeInfo(TYPE_INTEGER)
+	require.NoError(t, err)
+
+	var udf *chunkErrorSUDF
+	err = RegisterScalarUDF(conn, "chunk_error", udf)
+	require.NoError(t, err)
+
+	row := db.QueryRow(`SELECT chunk_error(10)`)
+	err = row.Scan(new(int32))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "test chunk execution error")
+}

--- a/scalar_udf_test.go
+++ b/scalar_udf_test.go
@@ -708,7 +708,7 @@ func (*chunkSumSUDF) Config() ScalarFuncConfig {
 func (*chunkSumSUDF) Executor() ScalarFuncExecutor {
 	return ScalarFuncExecutor{
 		ChunkContextExecutor: func(ctx context.Context, chunk *ScalarUDFChunk) error {
-			for row, _ := range chunk.Rows() {
+			for row := range chunk.Rows() {
 				// row.Args contains pre-fetched values
 				// NULL rows are automatically skipped when nullInNullOut is enabled
 				result := row.Args[0].(int32) + row.Args[1].(int32)
@@ -737,7 +737,7 @@ func (*chunkContextSUDF) Executor() ScalarFuncExecutor {
 				return errors.New("context does not contain the connection id for chunkContextSUDF")
 			}
 
-			for row, _ := range chunk.Rows() {
+			for row := range chunk.Rows() {
 				if err := row.SetResult(id); err != nil {
 					return err
 				}
@@ -755,7 +755,7 @@ func (*chunkNullHandlingSUDF) Config() ScalarFuncConfig {
 func (*chunkNullHandlingSUDF) Executor() ScalarFuncExecutor {
 	return ScalarFuncExecutor{
 		ChunkContextExecutor: func(ctx context.Context, chunk *ScalarUDFChunk) error {
-			for row, _ := range chunk.Rows() {
+			for row := range chunk.Rows() {
 				// With SpecialNullHandling: true, NULL rows are NOT skipped
 				// User must handle NULLs manually via row.Args
 				val := row.Args[0]
@@ -809,7 +809,7 @@ func TestChunkScalarUDF(t *testing.T) {
 
 	rows, err := db.Query(`SELECT a, b, chunk_sum(a, b) AS sum FROM test_chunk`)
 	require.NoError(t, err)
-	defer rows.Close()
+	defer closeRowsWrapper(t, rows)
 
 	count := 0
 	for rows.Next() {


### PR DESCRIPTION
The current Go scalar UDF API only supports row-by-row execution via RowExecutorFn.
The underlying C API already operates on chunks, but this wasn't exposed to Go users.

This PR adds ChunkContextExecutorFn that provides batch access to input rows with an ergonomic iterator-based API:
```go
ChunkContextExecutor: func(ctx context.Context, chunk *ScalarUDFChunk) error {
  rows, onFinish := chunk.Rows()
  for row := range rows {        
     result := row.Args[0].(int32) + row.Args[1].(int32)        
     row.SetResult(result)    
  }    
  return onFinish()
}
```

Key features:

- row.Args contains pre-fetched input values
- NULL rows are automatically skipped and their result set to NULL (respects SpecialNullHandling config)
- No pre-materialization of entire chunk - values fetched per-row during iteration