### PR TITLE
fix: C memory leak — defer captures nil/empty slice instead of final value (6 sites)

### DIFF
--- a/type_info.go
+++ b/type_info.go
@@ -446,7 +446,7 @@ func (info *typeInfo) logicalListType() mapping.LogicalType {
 
 func (info *typeInfo) logicalStructType() mapping.LogicalType {
 	var types []mapping.LogicalType
-	defer destroyLogicalTypes(types)
+	defer func() { destroyLogicalTypes(types) }()
 
 	var names []string
 	for _, entry := range info.structEntries {
@@ -472,7 +472,7 @@ func (info *typeInfo) logicalArrayType() mapping.LogicalType {
 
 func (info *typeInfo) logicalUnionType() mapping.LogicalType {
 	var types []mapping.LogicalType
-	defer destroyLogicalTypes(types)
+	defer func() { destroyLogicalTypes(types) }()
 	for _, t := range info.types {
 		types = append(types, t.logicalType())
 	}

--- a/value.go
+++ b/value.go
@@ -404,7 +404,7 @@ func inferSliceLogicalTypeAndValue[T any](val T, array bool, length int) (mappin
 	}
 
 	logicalTypes := make([]mapping.LogicalType, 0, length)
-	defer destroyLogicalTypes(logicalTypes)
+	defer func() { destroyLogicalTypes(logicalTypes) }()
 
 	var elemLogicalType mapping.LogicalType
 	expectedIndex := -1

--- a/value.go
+++ b/value.go
@@ -395,7 +395,7 @@ func inferSliceLogicalTypeAndValue[T any](val T, array bool, length int) (mappin
 	}
 
 	values := make([]mapping.Value, 0, length)
-	defer destroyValueSlice(values)
+	defer func() { destroyValueSlice(values) }()
 
 	if len(slice) == 0 {
 		lt := mapping.CreateLogicalType(TYPE_SQLNULL)
@@ -456,7 +456,7 @@ func createSliceValue[T any](lt mapping.LogicalType, t Type, val T) (mapping.Val
 	}
 
 	var values []mapping.Value
-	defer destroyValueSlice(values)
+	defer func() { destroyValueSlice(values) }()
 
 	for _, v := range slice {
 		vv, err := createValue(childType, v)
@@ -484,7 +484,7 @@ func createStructValue(lt mapping.LogicalType, val any) (mapping.Value, error) {
 	}
 
 	var values []mapping.Value
-	defer destroyValueSlice(values)
+	defer func() { destroyValueSlice(values) }()
 
 	childCount := mapping.StructTypeChildCount(lt)
 	for i := range uint64(childCount) {


### PR DESCRIPTION
## Summary

`defer f(x)` evaluates `x` **at the defer site**, not at function return. When `x` is a nil/empty slice that gets populated later via `append`, the deferred cleanup iterates over zero elements and **never frees the C objects**.

This affects two cleanup functions across **6 call sites** in `type_info.go` and `value.go`.

## The bug

Go spec: *"Each time a defer statement executes, the function value and parameters to the call are **evaluated as usual** and saved anew."*

```go
var types []mapping.LogicalType        // nil
defer destroyLogicalTypes(types)       // ← captures nil NOW

for _, entry := range info.structEntries {
    types = append(types, ...)         // types → new backing array
}
// function returns → destroyLogicalTypes(nil) → iterates 0 elements → LEAK
```

Verified with standalone program:
```
var s []int
defer fmt.Println("direct:", len(s))           // prints 0
defer func() { fmt.Println("closure:", len(s)) }()  // prints 3
s = append(s, 1, 2, 3)
```

## Affected functions

### `destroyLogicalTypes` — leaks C LogicalType objects

| Function | File | Leaked objects |
|----------|------|----------------|
| `logicalStructType` | type_info.go:448 | One LogicalType per STRUCT field |
| `logicalUnionType` | type_info.go:474 | One LogicalType per UNION member |
| `inferSliceLogicalTypeAndValue` | value.go:407 | One LogicalType per LIST/ARRAY element type |

### `destroyValueSlice` — leaks C Value objects

| Function | File | Leaked objects |
|----------|------|----------------|
| `inferSliceLogicalTypeAndValue` | value.go:398 | One Value per LIST/ARRAY element |
| `createSliceValue` | value.go:459 | One Value per LIST/ARRAY element |
| `createStructValue` | value.go:487 | One Value per STRUCT field |

These are called from Appender (STRUCT/LIST/ARRAY columns), prepared statement binding, scalar/table UDFs, and any code path that constructs composite types.

**Note on `destroyValueSlice` and double-free safety:** DuckDB's `Create*Value` functions (`CreateListValue`, `CreateArrayValue`, `CreateStructValue`) deep-copy input values via `allocValues` → `duckdb_create_*_value`. The original Value objects remain owned by the caller and must be destroyed separately — fixing the defer is not a double-free.

## Fix

Wrap all 6 defer calls in closures so they capture the **variable** (by reference), not its current **value**:

```go
defer func() { destroyLogicalTypes(types) }()
defer func() { destroyValueSlice(values) }()
```

The closure reads the variable at execution time (function return), when the slice is fully populated.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Behavior verified with standalone Go program demonstrating the defer evaluation semantics
- [ ] Reviewer: consider adding a test that checks for C object leaks (e.g., via DuckDB's debug allocation counter if exposed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)