### PR TITLE
Add concurrency group to CI workflow to cancel redundant runs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   go_test:
     name: Main Tests

--- a/.github/workflows/tidy_checks.yml
+++ b/.github/workflows/tidy_checks.yml
@@ -2,6 +2,10 @@ name: Tidy Checks
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
I noticed that we currently do not cancel in-progress runs on push.

<img width="1166" height="400" alt="image" src="https://github.com/user-attachments/assets/ee46e59e-f3d9-48c2-9ed8-f2672476ec23" />

Same change for bindings: https://github.com/duckdb/duckdb-go-bindings/pull/73