### PR TITLE
Support omitting named arguments in table UDFs

### DIFF
--- a/table_udf.go
+++ b/table_udf.go
@@ -187,11 +187,20 @@ func udfBindTyped[T tableSource](infoPtr unsafe.Pointer) {
 	}
 
 	for name := range config.NamedArguments {
-		var err error
 		value := mapping.BindGetNamedParameter(info, name)
+		lt := mapping.GetValueType(value)
+		t := mapping.GetTypeId(lt)
+
+		if t == TYPE_INVALID {
+			// Argument was omitted; pass nil so the bind function can apply a default.
+			mapping.DestroyValue(&value)
+			namedArgs[name] = nil
+			continue
+		}
+
+		var err error
 		namedArgs[name], err = getValue(value)
 		mapping.DestroyValue(&value)
-
 		if err != nil {
 			mapping.BindSetError(info, err.Error())
 			return

--- a/table_udf_test.go
+++ b/table_udf_test.go
@@ -51,6 +51,12 @@ type (
 		count int64
 	}
 
+	// incTableOptionalNamedUDF is like incTableNamedUDF but ARG is optional (defaults to 5).
+	incTableOptionalNamedUDF struct {
+		n     int64
+		count int64
+	}
+
 	constTableUDF[T any] struct {
 		count int64
 		value T
@@ -136,6 +142,18 @@ var (
 			name:        "incTableNamedUDF",
 			query:       `SELECT * FROM %s(ARG=2048)`,
 			resultCount: 2048,
+		},
+		{
+			udf:         &incTableOptionalNamedUDF{},
+			name:        "incTableOptionalNamedUDF_supplied",
+			query:       `SELECT * FROM %s(ARG=3)`,
+			resultCount: 3,
+		},
+		{
+			udf:         &incTableOptionalNamedUDF{},
+			name:        "incTableOptionalNamedUDF_omitted",
+			query:       `SELECT * FROM %s()`,
+			resultCount: 5, // default
 		},
 		{
 			udf:         &constTableUDF[bool]{value: false, t: TYPE_BOOLEAN},
@@ -650,6 +668,50 @@ func (udf *incTableNamedUDF) GetTypes() []any {
 }
 
 func (udf *incTableNamedUDF) Cardinality() *CardinalityInfo {
+	return nil
+}
+
+func (udf *incTableOptionalNamedUDF) GetFunction() RowTableFunction {
+	return RowTableFunction{
+		Config: TableFunctionConfig{
+			NamedArguments: map[string]TypeInfo{"ARG": typeBigintTableUDF},
+		},
+		BindArguments: bindIncTableOptionalNamedUDF,
+	}
+}
+
+func bindIncTableOptionalNamedUDF(namedArgs map[string]any, args ...any) (RowTableSource, error) {
+	n := int64(5) // default when ARG is omitted
+	if v := namedArgs["ARG"]; v != nil {
+		n = v.(int64)
+	}
+	return &incTableOptionalNamedUDF{n: n}, nil
+}
+
+func (udf *incTableOptionalNamedUDF) ColumnInfos() []ColumnInfo {
+	return []ColumnInfo{{Name: "result", T: typeBigintTableUDF}}
+}
+
+func (udf *incTableOptionalNamedUDF) Init() {}
+
+func (udf *incTableOptionalNamedUDF) FillRow(row Row) (bool, error) {
+	if udf.count >= udf.n {
+		return false, nil
+	}
+	udf.count++
+	err := SetRowValue(row, 0, udf.count)
+	return true, err
+}
+
+func (udf *incTableOptionalNamedUDF) GetValue(r, c int) any {
+	return int64(r + 1)
+}
+
+func (udf *incTableOptionalNamedUDF) GetTypes() []any {
+	return []any{0}
+}
+
+func (udf *incTableOptionalNamedUDF) Cardinality() *CardinalityInfo {
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- When a named argument is omitted, `duckdb_bind_get_named_parameter` returns a value with `DUCKDB_TYPE_INVALID`. Previously this propagated through `getValue()` and surfaced as `Binder Error: unsupported data type: INVALID`.
- Now, an omitted named argument inserts `nil` into the `namedArgs` map passed to `BindArguments`, allowing the user's bind function to detect the absence and apply its own default.
- No API changes — existing code that requires all named arguments continues to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)