### PR TITLE
Preserve NUL bytes in created VARCHAR values

### DIFF
--- a/replacement_scan.go
+++ b/replacement_scan.go
@@ -56,7 +56,7 @@ func replacement_scan_callback(infoPtr, tableNamePtr, data unsafe.Pointer) {
 	for _, param := range params {
 		switch paramType := param.(type) {
 		case string:
-			val := mapping.CreateVarchar(paramType)
+			val := mapping.CreateVarcharLength(paramType, mapping.IdxT(len(paramType)))
 			mapping.ReplacementScanAddParameter(info, val)
 			mapping.DestroyValue(&val)
 		case int64:
@@ -67,7 +67,7 @@ func replacement_scan_callback(infoPtr, tableNamePtr, data unsafe.Pointer) {
 			// Create values and logical type.
 			values := make([]mapping.Value, len(paramType))
 			for i, v := range paramType {
-				values[i] = mapping.CreateVarchar(v)
+				values[i] = mapping.CreateVarcharLength(v, mapping.IdxT(len(v)))
 			}
 			lt := mapping.CreateLogicalType(mapping.TypeVarchar)
 			val := mapping.CreateListValue(lt, values)

--- a/replacement_scan.go
+++ b/replacement_scan.go
@@ -56,7 +56,7 @@ func replacement_scan_callback(infoPtr, tableNamePtr, data unsafe.Pointer) {
 	for _, param := range params {
 		switch paramType := param.(type) {
 		case string:
-			val := mapping.CreateVarcharLength(paramType, mapping.IdxT(len(paramType)))
+			val := createVarchar(paramType)
 			mapping.ReplacementScanAddParameter(info, val)
 			mapping.DestroyValue(&val)
 		case int64:
@@ -67,7 +67,7 @@ func replacement_scan_callback(infoPtr, tableNamePtr, data unsafe.Pointer) {
 			// Create values and logical type.
 			values := make([]mapping.Value, len(paramType))
 			for i, v := range paramType {
-				values[i] = mapping.CreateVarcharLength(v, mapping.IdxT(len(v)))
+				values[i] = createVarchar(v)
 			}
 			lt := mapping.CreateLogicalType(mapping.TypeVarchar)
 			val := mapping.CreateListValue(lt, values)

--- a/replacement_scan_test.go
+++ b/replacement_scan_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const replacementScanStringWithNull = "Hello\x00World"
+
 // FIXME: More replacement scan tests, also failure paths.
 func TestReplacementScan(t *testing.T) {
 	c := newConnectorWrapper(t, ``, func(execer driver.ExecerContext) error {
@@ -53,4 +55,54 @@ func TestReplacementScanList(t *testing.T) {
 	var length int
 	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM any_table").Scan(&length))
 	require.Equal(t, 2, length)
+}
+
+func TestReplacementScanStringWithNullBytes(t *testing.T) {
+	c := newConnectorWrapper(t, ``, func(execer driver.ExecerContext) error {
+		_, err := execer.ExecContext(
+			t.Context(),
+			`CREATE MACRO replacement_string(s) AS TABLE SELECT s AS value`,
+			nil,
+		)
+		return err
+	})
+	defer closeConnectorWrapper(t, c)
+
+	input := replacementScanStringWithNull
+	RegisterReplacementScan(c, func(tableName string) (string, []any, error) {
+		return "replacement_string", []any{input}, nil
+	})
+
+	db := sql.OpenDB(c)
+	defer closeDbWrapper(t, db)
+
+	var got string
+	require.NoError(t, db.QueryRow("SELECT value FROM any_table").Scan(&got))
+	require.Equal(t, input, got)
+	require.Len(t, got, len(input))
+}
+
+func TestReplacementScanStringListWithNullBytes(t *testing.T) {
+	c := newConnectorWrapper(t, ``, func(execer driver.ExecerContext) error {
+		_, err := execer.ExecContext(
+			t.Context(),
+			`CREATE MACRO replacement_string_list(vals) AS TABLE SELECT unnest(vals) AS value`,
+			nil,
+		)
+		return err
+	})
+	defer closeConnectorWrapper(t, c)
+
+	input := replacementScanStringWithNull
+	RegisterReplacementScan(c, func(tableName string) (string, []any, error) {
+		return "replacement_string_list", []any{[]string{input}}, nil
+	})
+
+	db := sql.OpenDB(c)
+	defer closeDbWrapper(t, db)
+
+	var got string
+	require.NoError(t, db.QueryRow("SELECT value FROM any_table").Scan(&got))
+	require.Equal(t, input, got)
+	require.Len(t, got, len(input))
 }

--- a/replacement_scan_test.go
+++ b/replacement_scan_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const replacementScanStringWithNull = "Hello\x00World"
-
 // FIXME: More replacement scan tests, also failure paths.
 func TestReplacementScan(t *testing.T) {
 	c := newConnectorWrapper(t, ``, func(execer driver.ExecerContext) error {
@@ -58,51 +56,57 @@ func TestReplacementScanList(t *testing.T) {
 }
 
 func TestReplacementScanStringWithNullBytes(t *testing.T) {
-	c := newConnectorWrapper(t, ``, func(execer driver.ExecerContext) error {
-		_, err := execer.ExecContext(
-			t.Context(),
-			`CREATE MACRO replacement_string(s) AS TABLE SELECT s AS value`,
-			nil,
-		)
-		return err
-	})
-	defer closeConnectorWrapper(t, c)
+	for _, tc := range nullByteStringTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newConnectorWrapper(t, ``, func(execer driver.ExecerContext) error {
+				_, err := execer.ExecContext(
+					t.Context(),
+					`CREATE MACRO replacement_string(s) AS TABLE SELECT s AS value`,
+					nil,
+				)
+				return err
+			})
+			defer closeConnectorWrapper(t, c)
 
-	input := replacementScanStringWithNull
-	RegisterReplacementScan(c, func(tableName string) (string, []any, error) {
-		return "replacement_string", []any{input}, nil
-	})
+			RegisterReplacementScan(c, func(tableName string) (string, []any, error) {
+				return "replacement_string", []any{tc.input}, nil
+			})
 
-	db := sql.OpenDB(c)
-	defer closeDbWrapper(t, db)
+			db := sql.OpenDB(c)
+			defer closeDbWrapper(t, db)
 
-	var got string
-	require.NoError(t, db.QueryRow("SELECT value FROM any_table").Scan(&got))
-	require.Equal(t, input, got)
-	require.Len(t, got, len(input))
+			var got string
+			require.NoError(t, db.QueryRow("SELECT value FROM any_table").Scan(&got))
+			require.Equal(t, tc.input, got)
+			require.Len(t, got, len(tc.input))
+		})
+	}
 }
 
 func TestReplacementScanStringListWithNullBytes(t *testing.T) {
-	c := newConnectorWrapper(t, ``, func(execer driver.ExecerContext) error {
-		_, err := execer.ExecContext(
-			t.Context(),
-			`CREATE MACRO replacement_string_list(vals) AS TABLE SELECT unnest(vals) AS value`,
-			nil,
-		)
-		return err
-	})
-	defer closeConnectorWrapper(t, c)
+	for _, tc := range nullByteStringTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newConnectorWrapper(t, ``, func(execer driver.ExecerContext) error {
+				_, err := execer.ExecContext(
+					t.Context(),
+					`CREATE MACRO replacement_string_list(vals) AS TABLE SELECT unnest(vals) AS value`,
+					nil,
+				)
+				return err
+			})
+			defer closeConnectorWrapper(t, c)
 
-	input := replacementScanStringWithNull
-	RegisterReplacementScan(c, func(tableName string) (string, []any, error) {
-		return "replacement_string_list", []any{[]string{input}}, nil
-	})
+			RegisterReplacementScan(c, func(tableName string) (string, []any, error) {
+				return "replacement_string_list", []any{[]string{tc.input}}, nil
+			})
 
-	db := sql.OpenDB(c)
-	defer closeDbWrapper(t, db)
+			db := sql.OpenDB(c)
+			defer closeDbWrapper(t, db)
 
-	var got string
-	require.NoError(t, db.QueryRow("SELECT value FROM any_table").Scan(&got))
-	require.Equal(t, input, got)
-	require.Len(t, got, len(input))
+			var got string
+			require.NoError(t, db.QueryRow("SELECT value FROM any_table").Scan(&got))
+			require.Equal(t, tc.input, got)
+			require.Len(t, got, len(tc.input))
+		})
+	}
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -1593,25 +1593,31 @@ func TestTimestampBinding(t *testing.T) {
 	require.Equal(t, 13, expectedCount)
 }
 
+var nullByteStringTestCases = []struct {
+	name  string
+	input string
+}{
+	{"multiple nulls", "a\x00b\x00c\x00"},
+	{"null in middle", "Hello\x00World"},
+	{"null after first char", "A\x00BCDEFG"},
+	{"only null", "\x00"},
+	{"null at start", "\x00Hello"},
+	{"null at end", "Hello\x00"},
+}
+
+type nullByteStringer string
+
+func (s nullByteStringer) String() string {
+	return string(s)
+}
+
 func TestBindStringWithNullBytes(t *testing.T) {
 	db := openDbWrapper(t, ``)
 	defer closeDbWrapper(t, db)
 
 	createTable(t, db, `CREATE TABLE null_byte_test (id INTEGER PRIMARY KEY, text_value VARCHAR)`)
 
-	testCases := []struct {
-		name  string
-		input string
-	}{
-		{"multiple nulls", "a\x00b\x00c\x00"},
-		{"null in middle", "Hello\x00World"},
-		{"null after first char", "A\x00BCDEFG"},
-		{"only null", "\x00"},
-		{"null at start", "\x00Hello"},
-		{"null at end", "Hello\x00"},
-	}
-
-	for i, tc := range testCases {
+	for i, tc := range nullByteStringTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := db.Exec("INSERT INTO null_byte_test (id, text_value) VALUES (?, ?)", i, tc.input)
 			require.NoError(t, err)
@@ -1629,13 +1635,30 @@ func TestBindStringListWithNullBytes(t *testing.T) {
 	db := openDbWrapper(t, ``)
 	defer closeDbWrapper(t, db)
 
-	input := "Hello\x00World"
+	for _, tc := range nullByteStringTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got Composite[[]string]
+			err := db.QueryRow(`SELECT ?::VARCHAR[]`, []string{tc.input}).Scan(&got)
+			require.NoError(t, err)
+			require.Equal(t, []string{tc.input}, got.Get())
+			require.Len(t, got.Get()[0], len(tc.input))
+		})
+	}
+}
 
-	var got Composite[[]string]
-	err := db.QueryRow(`SELECT ?::VARCHAR[]`, []string{input}).Scan(&got)
-	require.NoError(t, err)
-	require.Equal(t, []string{input}, got.Get())
-	require.Len(t, got.Get()[0], len(input))
+func TestBindStringerWithNullBytes(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	for _, tc := range nullByteStringTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			err := db.QueryRow(`SELECT ?`, nullByteStringer(tc.input)).Scan(&got)
+			require.NoError(t, err)
+			require.Equal(t, tc.input, got)
+			require.Len(t, got, len(tc.input))
+		})
+	}
 }
 
 func TestBindBlobWithNullBytes(t *testing.T) {

--- a/statement_test.go
+++ b/statement_test.go
@@ -1625,6 +1625,19 @@ func TestBindStringWithNullBytes(t *testing.T) {
 	}
 }
 
+func TestBindStringListWithNullBytes(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	input := "Hello\x00World"
+
+	var got Composite[[]string]
+	err := db.QueryRow(`SELECT ?::VARCHAR[]`, []string{input}).Scan(&got)
+	require.NoError(t, err)
+	require.Equal(t, []string{input}, got.Get())
+	require.Len(t, got.Get()[0], len(input))
+}
+
 func TestBindBlobWithNullBytes(t *testing.T) {
 	db := openDbWrapper(t, ``)
 	defer closeDbWrapper(t, db)

--- a/value.go
+++ b/value.go
@@ -9,6 +9,10 @@ import (
 	"github.com/duckdb/duckdb-go/v2/mapping"
 )
 
+func createVarchar(s string) mapping.Value {
+	return mapping.CreateVarcharLength(s, mapping.IdxT(len(s)))
+}
+
 func getValue(v mapping.Value) (any, error) {
 	// The logical type is valid as long as v (mapping.Value) is valid,
 	// i.e., it must not be destroyed.
@@ -132,8 +136,7 @@ func createPrimitiveValue(t mapping.Type, v any) (mapping.Value, error) {
 	case TYPE_DOUBLE:
 		return mapping.CreateDouble(v.(float64)), nil
 	case TYPE_VARCHAR:
-		vv := v.(string)
-		return mapping.CreateVarcharLength(vv, mapping.IdxT(len(vv))), nil
+		return createVarchar(v.(string)), nil
 	case TYPE_TIMESTAMP:
 		vv, err := inferTimestamp(t, v)
 		if err != nil {

--- a/value.go
+++ b/value.go
@@ -132,7 +132,8 @@ func createPrimitiveValue(t mapping.Type, v any) (mapping.Value, error) {
 	case TYPE_DOUBLE:
 		return mapping.CreateDouble(v.(float64)), nil
 	case TYPE_VARCHAR:
-		return mapping.CreateVarchar(v.(string)), nil
+		vv := v.(string)
+		return mapping.CreateVarcharLength(vv, mapping.IdxT(len(vv))), nil
 	case TYPE_TIMESTAMP:
 		vv, err := inferTimestamp(t, v)
 		if err != nil {


### PR DESCRIPTION
Follow-up to #109. This fixes the remaining embedded-NUL `VARCHAR` truncation paths that still used C-string value constructors instead of length-aware constructors.