### PR TITLE
Add Typed for explicit scalar parameter binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,26 @@ When passing a `time.Time` to duckdb-go, duckdb-go transforms it to an instant w
 even when using `TIMESTAMP_TZ`. Later, scanning either type of value returns an instant, as SQL types do not model
 time zone information for individual values.
 
+Use `duckdb.Typed(value, typ)` to force the DuckDB logical type used when binding a query parameter.
+This is useful when DuckDB cannot infer the desired parameter type from SQL alone, or when duckdb-go's
+default Go-type inference would choose a different DuckDB type.
+
+```go
+start := time.Date(2024, time.April, 5, 0, 0, 0, 0, time.UTC)
+end := time.Date(2024, time.April, 6, 0, 0, 0, 0, time.UTC)
+
+row := db.QueryRow(`
+	SELECT COUNT(*)
+	FROM (VALUES
+		(TIMESTAMP_NS '2024-04-05 12:00:00.000000001')
+	) events_ns(ts)
+	WHERE ts >= ? AND ts < ?
+`, duckdb.Typed(start, duckdb.TYPE_TIMESTAMP_NS), duckdb.Typed(end, duckdb.TYPE_TIMESTAMP_NS))
+```
+
+In this example, the wrapper ensures the parameters bind as `TIMESTAMP_NS`. Bare `time.Time` values bind as
+`TIMESTAMP_TZ` by default. `Typed` is a narrow scalar binding hint; validation happens when the parameter is bound.
+
 **Connection lifetime**
 
 Temporary objects and state, such as temporary tables, are scoped to connections.

--- a/connection.go
+++ b/connection.go
@@ -37,7 +37,7 @@ func newConn(conn mapping.Connection, ctxStore *contextStore) *Conn {
 // CheckNamedValue implements the driver.NamedValueChecker interface.
 func (conn *Conn) CheckNamedValue(nv *driver.NamedValue) error {
 	switch nv.Value.(type) {
-	case *big.Int, Interval, Bit, *Bit, []any, []bool, []int8, []int16, []int32, []int64, []int, []uint8, []uint16,
+	case TypedValue, *TypedValue, *big.Int, Interval, Bit, *Bit, []any, []bool, []int8, []int16, []int32, []int64, []int, []uint8, []uint16,
 		[]uint32, []uint64, []uint, []float32, []float64, []string, map[string]any, OrderedMap:
 		return nil
 	}

--- a/errors.go
+++ b/errors.go
@@ -3,6 +3,7 @@ package duckdb
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/duckdb/duckdb-go/v2/mapping"
@@ -17,6 +18,14 @@ func getError(errDriver, err error) error {
 
 func castError(actual, expected string) error {
 	return fmt.Errorf("%s: cannot cast %s to %s", castErrMsg, actual, expected)
+}
+
+func castErrorForValue(v any, expected string) error {
+	actual := "<nil>"
+	if v != nil {
+		actual = reflect.TypeOf(v).String()
+	}
+	return castError(actual, expected)
 }
 
 func conversionError(actual, min, max int) error {

--- a/statement.go
+++ b/statement.go
@@ -360,8 +360,51 @@ func (s *Stmt) bindComplexValue(val driver.NamedValue, n int, t Type, name strin
 	return mapping.StateError, addIndexToError(unsupportedTypeError(unknownTypeErrMsg), n+1)
 }
 
+func (s *Stmt) bindTypedValue(val TypedValue, n int) (mapping.State, error) {
+	value := val.value
+	// Unwrap driver.Valuer unless the caller already signalled NULL.
+	// Calling Value() on a typed-nil receiver can panic.
+	if val.typ != TYPE_SQLNULL && !isNil(value) {
+		if valuer, ok := value.(driver.Valuer); ok {
+			driverVal, err := valuer.Value()
+			if err != nil {
+				return mapping.StateError, addIndexToError(err, n+1)
+			}
+			value = driverVal
+		}
+	}
+
+	coerced, err := coerceTypedValue(val.typ, value)
+	if err != nil {
+		return mapping.StateError, addIndexToError(err, n+1)
+	}
+	if coerced == nil {
+		return mapping.BindNull(*s.preparedStmt, mapping.IdxT(n+1)), nil
+	}
+
+	// TypedValue only admits scalar types, which createPrimitiveValue handles
+	// without needing a mapping.LogicalType.
+	mappedVal, err := createPrimitiveValue(val.typ, coerced)
+	if err != nil {
+		return mapping.StateError, addIndexToError(err, n+1)
+	}
+	defer mapping.DestroyValue(&mappedVal)
+
+	return mapping.BindValue(*s.preparedStmt, mapping.IdxT(n+1), mappedVal), nil
+}
+
 //nolint:gocyclo
 func (s *Stmt) bindValue(val driver.NamedValue, n int) (mapping.State, error) {
+	switch explicit := val.Value.(type) {
+	case TypedValue:
+		return s.bindTypedValue(explicit, n)
+	case *TypedValue:
+		if explicit == nil {
+			return mapping.BindNull(*s.preparedStmt, mapping.IdxT(n+1)), nil
+		}
+		return s.bindTypedValue(*explicit, n)
+	}
+
 	// For some queries, we cannot resolve the parameter type when preparing the query.
 	// E.g., for "SELECT * FROM (VALUES (?, ?)) t(a, b)", we cannot know the parameter types from the SQL statement alone.
 	// For these cases, ParamType returns TYPE_INVALID.

--- a/statement.go
+++ b/statement.go
@@ -385,10 +385,10 @@ func (s *Stmt) bindTypedValue(val TypedValue, n int) (mapping.State, error) {
 	// TypedValue only admits scalar types, which createPrimitiveValue handles
 	// without needing a mapping.LogicalType.
 	mappedVal, err := createPrimitiveValue(val.typ, coerced)
+	defer mapping.DestroyValue(&mappedVal)
 	if err != nil {
 		return mapping.StateError, addIndexToError(err, n+1)
 	}
-	defer mapping.DestroyValue(&mappedVal)
 
 	return mapping.BindValue(*s.preparedStmt, mapping.IdxT(n+1), mappedVal), nil
 }

--- a/statement.go
+++ b/statement.go
@@ -382,8 +382,6 @@ func (s *Stmt) bindTypedValue(val TypedValue, n int) (mapping.State, error) {
 		return mapping.BindNull(*s.preparedStmt, mapping.IdxT(n+1)), nil
 	}
 
-	// TypedValue only admits scalar types, which createPrimitiveValue handles
-	// without needing a mapping.LogicalType.
 	mappedVal, err := createPrimitiveValue(val.typ, coerced)
 	defer mapping.DestroyValue(&mappedVal)
 	if err != nil {

--- a/typed_value.go
+++ b/typed_value.go
@@ -1,0 +1,208 @@
+package duckdb
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+)
+
+// TypedValue wraps a Go value with an explicit DuckDB type for parameter
+// binding. Use it when DuckDB cannot infer the parameter type from SQL alone,
+// or when the default Go-type inference would choose a different DuckDB type.
+//
+// TypedValue is intentionally a narrow binding hint rather than a general
+// conversion API. It selects the DuckDB parameter type while preserving the
+// usual Go value semantics for that type.
+//
+// Typed parameters support scalar types that can be represented by a bare Type
+// enum. Types that need extra logical type metadata, such as DECIMAL, ENUM,
+// LIST, ARRAY, STRUCT, MAP, and UNION are rejected. UUID, BIT, BLOB, HUGEINT,
+// UHUGEINT, and BIGNUM are also outside the Typed scope for now.
+//
+// If the type is TYPE_SQLNULL, the value is ignored without calling
+// driver.Valuer and the parameter is bound as SQL NULL. A nil value, including
+// a nil *TypedValue argument, also binds SQL NULL.
+//
+// Coercions are intentionally narrow: TYPE_BOOLEAN accepts only bool,
+// TYPE_VARCHAR accepts only string. Integer types accept Go integer values in
+// range. Floating-point types accept only Go float32 or float64 values.
+// TYPE_FLOAT rejects finite float64 values that would overflow or underflow to
+// zero as float32. NaN and infinities are preserved.
+type TypedValue struct {
+	value any
+	typ   Type
+}
+
+// Typed returns a TypedValue for explicit DuckDB parameter binding. Validation
+// happens when the value is bound, so Typed remains a lightweight wrapper with
+// the same call shape for every supported target type.
+func Typed(value any, typ Type) TypedValue {
+	return TypedValue{
+		value: value,
+		typ:   typ,
+	}
+}
+
+func coerceTypedValue(t Type, v any) (any, error) {
+	if !supportsTypedValue(t) {
+		return nil, unsupportedTypeError(typedValueTypeName(t))
+	}
+
+	if t == TYPE_SQLNULL || isNil(v) {
+		return nil, nil
+	}
+
+	switch t {
+	case TYPE_BOOLEAN:
+		if _, ok := v.(bool); ok {
+			return v, nil
+		}
+		return nil, typedValueCastError(t, v)
+	case TYPE_TINYINT:
+		i, err := coerceTypedSignedInteger(t, v, math.MinInt8, math.MaxInt8)
+		return int8(i), err
+	case TYPE_SMALLINT:
+		i, err := coerceTypedSignedInteger(t, v, math.MinInt16, math.MaxInt16)
+		return int16(i), err
+	case TYPE_INTEGER:
+		i, err := coerceTypedSignedInteger(t, v, math.MinInt32, math.MaxInt32)
+		return int32(i), err
+	case TYPE_BIGINT:
+		return coerceTypedSignedInteger(t, v, math.MinInt64, math.MaxInt64)
+	case TYPE_UTINYINT:
+		i, err := coerceTypedUnsignedInteger(t, v, math.MaxUint8)
+		return uint8(i), err
+	case TYPE_USMALLINT:
+		i, err := coerceTypedUnsignedInteger(t, v, math.MaxUint16)
+		return uint16(i), err
+	case TYPE_UINTEGER:
+		i, err := coerceTypedUnsignedInteger(t, v, math.MaxUint32)
+		return uint32(i), err
+	case TYPE_UBIGINT:
+		return coerceTypedUnsignedInteger(t, v, math.MaxUint64)
+	case TYPE_FLOAT:
+		return coerceTypedFloat32(t, v)
+	case TYPE_DOUBLE:
+		return coerceTypedFloat64(t, v)
+	case TYPE_VARCHAR:
+		if _, ok := v.(string); ok {
+			return v, nil
+		}
+		return nil, typedValueCastError(t, v)
+	case TYPE_TIMESTAMP, TYPE_TIMESTAMP_TZ, TYPE_TIMESTAMP_S, TYPE_TIMESTAMP_MS, TYPE_TIMESTAMP_NS,
+		TYPE_DATE, TYPE_TIME, TYPE_TIME_TZ, TYPE_INTERVAL:
+		return v, nil
+	}
+	return nil, fmt.Errorf("duckdb: internal error: missing typed value coercion for %s", typedValueTypeName(t))
+}
+
+func supportsTypedValue(t Type) bool {
+	switch t {
+	case TYPE_BOOLEAN, TYPE_TINYINT, TYPE_SMALLINT, TYPE_INTEGER, TYPE_BIGINT,
+		TYPE_UTINYINT, TYPE_USMALLINT, TYPE_UINTEGER, TYPE_UBIGINT,
+		TYPE_FLOAT, TYPE_DOUBLE, TYPE_VARCHAR,
+		TYPE_TIMESTAMP, TYPE_TIMESTAMP_TZ, TYPE_TIMESTAMP_S, TYPE_TIMESTAMP_MS, TYPE_TIMESTAMP_NS,
+		TYPE_DATE, TYPE_TIME, TYPE_TIME_TZ, TYPE_INTERVAL,
+		TYPE_SQLNULL:
+		return true
+	default:
+		return false
+	}
+}
+
+func coerceTypedSignedInteger(t Type, v any, min, max int64) (int64, error) {
+	value := reflect.ValueOf(v)
+	switch value.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return coerceTypedSignedRange(t, value.Int(), min, max)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return coerceTypedUnsignedToSigned(t, value.Uint(), max)
+	default:
+		return 0, typedValueCastError(t, v)
+	}
+}
+
+func coerceTypedSignedRange(t Type, v, min, max int64) (int64, error) {
+	if v < min || v > max {
+		return 0, typedValueConversionError(t, v)
+	}
+	return v, nil
+}
+
+func coerceTypedUnsignedToSigned(t Type, v uint64, max int64) (int64, error) {
+	if v > uint64(max) {
+		return 0, typedValueConversionError(t, v)
+	}
+	return int64(v), nil
+}
+
+func coerceTypedUnsignedInteger(t Type, v any, max uint64) (uint64, error) {
+	value := reflect.ValueOf(v)
+	switch value.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return coerceTypedSignedToUnsigned(t, value.Int(), max)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return coerceTypedUnsignedRange(t, value.Uint(), max)
+	default:
+		return 0, typedValueCastError(t, v)
+	}
+}
+
+func coerceTypedSignedToUnsigned(t Type, v int64, max uint64) (uint64, error) {
+	if v < 0 || uint64(v) > max {
+		return 0, typedValueConversionError(t, v)
+	}
+	return uint64(v), nil
+}
+
+func coerceTypedUnsignedRange(t Type, v, max uint64) (uint64, error) {
+	if v > max {
+		return 0, typedValueConversionError(t, v)
+	}
+	return v, nil
+}
+
+func coerceTypedFloat32(t Type, v any) (float32, error) {
+	switch vv := v.(type) {
+	case float32:
+		return vv, nil
+	case float64:
+		// Avoid silently converting finite float64 values to float32 infinities or zero.
+		if !math.IsInf(vv, 0) && math.Abs(vv) > math.MaxFloat32 {
+			return 0, typedValueConversionError(t, v)
+		}
+		if vv != 0 && float32(vv) == 0 {
+			return 0, typedValueConversionError(t, v)
+		}
+		return float32(vv), nil
+	default:
+		return 0, typedValueCastError(t, v)
+	}
+}
+
+func coerceTypedFloat64(t Type, v any) (float64, error) {
+	switch vv := v.(type) {
+	case float32:
+		return float64(vv), nil
+	case float64:
+		return vv, nil
+	default:
+		return 0, typedValueCastError(t, v)
+	}
+}
+
+func typedValueCastError(t Type, v any) error {
+	return castErrorForValue(v, typedValueTypeName(t))
+}
+
+func typedValueConversionError(t Type, v any) error {
+	return fmt.Errorf("%s: cannot convert %v to %s", convertErrMsg, v, typedValueTypeName(t))
+}
+
+func typedValueTypeName(t Type) string {
+	name, ok := typeToStringMap[t]
+	if !ok {
+		return unknownTypeErrMsg
+	}
+	return name
+}

--- a/typed_value.go
+++ b/typed_value.go
@@ -60,30 +60,34 @@ func coerceTypedValue(t Type, v any) (any, error) {
 		return nil, typedValueCastError(t, v)
 	case TYPE_TINYINT:
 		i, err := coerceTypedSignedInteger(t, v, math.MinInt8, math.MaxInt8)
-		return int8(i), err
+		return typedCoercionResult(int8(i), err)
 	case TYPE_SMALLINT:
 		i, err := coerceTypedSignedInteger(t, v, math.MinInt16, math.MaxInt16)
-		return int16(i), err
+		return typedCoercionResult(int16(i), err)
 	case TYPE_INTEGER:
 		i, err := coerceTypedSignedInteger(t, v, math.MinInt32, math.MaxInt32)
-		return int32(i), err
+		return typedCoercionResult(int32(i), err)
 	case TYPE_BIGINT:
-		return coerceTypedSignedInteger(t, v, math.MinInt64, math.MaxInt64)
+		i, err := coerceTypedSignedInteger(t, v, math.MinInt64, math.MaxInt64)
+		return typedCoercionResult(i, err)
 	case TYPE_UTINYINT:
 		i, err := coerceTypedUnsignedInteger(t, v, math.MaxUint8)
-		return uint8(i), err
+		return typedCoercionResult(uint8(i), err)
 	case TYPE_USMALLINT:
 		i, err := coerceTypedUnsignedInteger(t, v, math.MaxUint16)
-		return uint16(i), err
+		return typedCoercionResult(uint16(i), err)
 	case TYPE_UINTEGER:
 		i, err := coerceTypedUnsignedInteger(t, v, math.MaxUint32)
-		return uint32(i), err
+		return typedCoercionResult(uint32(i), err)
 	case TYPE_UBIGINT:
-		return coerceTypedUnsignedInteger(t, v, math.MaxUint64)
+		i, err := coerceTypedUnsignedInteger(t, v, math.MaxUint64)
+		return typedCoercionResult(i, err)
 	case TYPE_FLOAT:
-		return coerceTypedFloat32(t, v)
+		f, err := coerceTypedFloat32(t, v)
+		return typedCoercionResult(f, err)
 	case TYPE_DOUBLE:
-		return coerceTypedFloat64(t, v)
+		f, err := coerceTypedFloat64(t, v)
+		return typedCoercionResult(f, err)
 	case TYPE_VARCHAR:
 		if _, ok := v.(string); ok {
 			return v, nil
@@ -108,6 +112,13 @@ func supportsTypedValue(t Type) bool {
 	default:
 		return false
 	}
+}
+
+func typedCoercionResult[T any](v T, err error) (any, error) {
+	if err != nil {
+		return nil, err
+	}
+	return v, nil
 }
 
 func coerceTypedSignedInteger(t Type, v any, min, max int64) (int64, error) {

--- a/typed_value.go
+++ b/typed_value.go
@@ -12,12 +12,9 @@ import (
 //
 // TypedValue is intentionally a narrow binding hint rather than a general
 // conversion API. It selects the DuckDB parameter type while preserving the
-// usual Go value semantics for that type.
-//
-// Typed parameters support scalar types that can be represented by a bare Type
-// enum. Types that need extra logical type metadata, such as DECIMAL, ENUM,
-// LIST, ARRAY, STRUCT, MAP, and UNION are rejected. UUID, BIT, BLOB, HUGEINT,
-// UHUGEINT, and BIGNUM are also outside the Typed scope for now.
+// usual Go value semantics for that type. supportsTypedValue is the
+// authoritative list of accepted target types; types that need extra logical
+// type metadata (DECIMAL, ENUM, LIST, ARRAY, STRUCT, MAP, UNION) are rejected.
 //
 // If the type is TYPE_SQLNULL, the value is ignored without calling
 // driver.Valuer and the parameter is bound as SQL NULL. A nil value, including
@@ -33,9 +30,8 @@ type TypedValue struct {
 	typ   Type
 }
 
-// Typed returns a TypedValue for explicit DuckDB parameter binding. Validation
-// happens when the value is bound, so Typed remains a lightweight wrapper with
-// the same call shape for every supported target type.
+// Typed returns a TypedValue for explicit DuckDB parameter binding.
+// Validation is deferred until the value is bound.
 func Typed(value any, typ Type) TypedValue {
 	return TypedValue{
 		value: value,
@@ -83,11 +79,9 @@ func coerceTypedValue(t Type, v any) (any, error) {
 		i, err := coerceTypedUnsignedInteger(t, v, math.MaxUint64)
 		return typedCoercionResult(i, err)
 	case TYPE_FLOAT:
-		f, err := coerceTypedFloat32(t, v)
-		return typedCoercionResult(f, err)
+		return coerceTypedFloat32(t, v)
 	case TYPE_DOUBLE:
-		f, err := coerceTypedFloat64(t, v)
-		return typedCoercionResult(f, err)
+		return coerceTypedFloat64(t, v)
 	case TYPE_VARCHAR:
 		if _, ok := v.(string); ok {
 			return v, nil
@@ -125,80 +119,68 @@ func coerceTypedSignedInteger(t Type, v any, min, max int64) (int64, error) {
 	value := reflect.ValueOf(v)
 	switch value.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return coerceTypedSignedRange(t, value.Int(), min, max)
+		i := value.Int()
+		if i < min || i > max {
+			return 0, typedValueConversionError(t, i)
+		}
+		return i, nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return coerceTypedUnsignedToSigned(t, value.Uint(), max)
+		u := value.Uint()
+		if u > uint64(max) {
+			return 0, typedValueConversionError(t, u)
+		}
+		return int64(u), nil
 	default:
 		return 0, typedValueCastError(t, v)
 	}
-}
-
-func coerceTypedSignedRange(t Type, v, min, max int64) (int64, error) {
-	if v < min || v > max {
-		return 0, typedValueConversionError(t, v)
-	}
-	return v, nil
-}
-
-func coerceTypedUnsignedToSigned(t Type, v uint64, max int64) (int64, error) {
-	if v > uint64(max) {
-		return 0, typedValueConversionError(t, v)
-	}
-	return int64(v), nil
 }
 
 func coerceTypedUnsignedInteger(t Type, v any, max uint64) (uint64, error) {
 	value := reflect.ValueOf(v)
 	switch value.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return coerceTypedSignedToUnsigned(t, value.Int(), max)
+		i := value.Int()
+		if i < 0 || uint64(i) > max {
+			return 0, typedValueConversionError(t, i)
+		}
+		return uint64(i), nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return coerceTypedUnsignedRange(t, value.Uint(), max)
+		u := value.Uint()
+		if u > max {
+			return 0, typedValueConversionError(t, u)
+		}
+		return u, nil
 	default:
 		return 0, typedValueCastError(t, v)
 	}
 }
 
-func coerceTypedSignedToUnsigned(t Type, v int64, max uint64) (uint64, error) {
-	if v < 0 || uint64(v) > max {
-		return 0, typedValueConversionError(t, v)
-	}
-	return uint64(v), nil
-}
-
-func coerceTypedUnsignedRange(t Type, v, max uint64) (uint64, error) {
-	if v > max {
-		return 0, typedValueConversionError(t, v)
-	}
-	return v, nil
-}
-
-func coerceTypedFloat32(t Type, v any) (float32, error) {
+func coerceTypedFloat32(t Type, v any) (any, error) {
 	switch vv := v.(type) {
 	case float32:
 		return vv, nil
 	case float64:
 		// Avoid silently converting finite float64 values to float32 infinities or zero.
 		if !math.IsInf(vv, 0) && math.Abs(vv) > math.MaxFloat32 {
-			return 0, typedValueConversionError(t, v)
+			return nil, typedValueConversionError(t, vv)
 		}
 		if vv != 0 && float32(vv) == 0 {
-			return 0, typedValueConversionError(t, v)
+			return nil, typedValueConversionError(t, vv)
 		}
 		return float32(vv), nil
 	default:
-		return 0, typedValueCastError(t, v)
+		return nil, typedValueCastError(t, v)
 	}
 }
 
-func coerceTypedFloat64(t Type, v any) (float64, error) {
+func coerceTypedFloat64(t Type, v any) (any, error) {
 	switch vv := v.(type) {
 	case float32:
 		return float64(vv), nil
 	case float64:
 		return vv, nil
 	default:
-		return 0, typedValueCastError(t, v)
+		return nil, typedValueCastError(t, v)
 	}
 }
 
@@ -211,9 +193,8 @@ func typedValueConversionError(t Type, v any) error {
 }
 
 func typedValueTypeName(t Type) string {
-	name, ok := typeToStringMap[t]
-	if !ok {
-		return unknownTypeErrMsg
+	if name, ok := typeToStringMap[t]; ok {
+		return name
 	}
-	return name
+	return unknownTypeErrMsg
 }

--- a/typed_value_test.go
+++ b/typed_value_test.go
@@ -180,6 +180,16 @@ func TestTypedRepresentativeScalars(t *testing.T) {
 		require.Equal(t, want, got)
 	})
 
+	t.Run("date and time", func(t *testing.T) {
+		want := time.Date(2024, time.April, 5, 12, 34, 56, 0, time.UTC)
+		var gotDate time.Time
+		var gotTime time.Time
+		err := db.QueryRow(`SELECT ?, ?`, Typed(want, TYPE_DATE), Typed(want, TYPE_TIME)).Scan(&gotDate, &gotTime)
+		require.NoError(t, err)
+		require.Equal(t, time.Date(2024, time.April, 5, 0, 0, 0, 0, time.UTC), gotDate)
+		require.Equal(t, time.Date(1, time.January, 1, 12, 34, 56, 0, time.UTC), gotTime)
+	})
+
 	t.Run("interval", func(t *testing.T) {
 		want := Interval{Days: 10, Months: 4, Micros: 123456}
 		var got Interval
@@ -207,9 +217,24 @@ func TestTypedNullAndValuerBinding(t *testing.T) {
 		require.Nil(t, got)
 	})
 
+	t.Run("sqlnull accepts nil", func(t *testing.T) {
+		var got any
+		err := db.QueryRow(`SELECT ?`, Typed(nil, TYPE_SQLNULL)).Scan(&got)
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
 	t.Run("valuer result is coerced", func(t *testing.T) {
 		var got int32
 		err := db.QueryRow(`SELECT ?`, Typed(typedIntValuer(42), TYPE_INTEGER)).Scan(&got)
+		require.NoError(t, err)
+		require.Equal(t, int32(42), got)
+	})
+
+	t.Run("typed value pointer binds value", func(t *testing.T) {
+		var got int32
+		typed := Typed(42, TYPE_INTEGER)
+		err := db.QueryRow(`SELECT ?`, &typed).Scan(&got)
 		require.NoError(t, err)
 		require.Equal(t, int32(42), got)
 	})

--- a/typed_value_test.go
+++ b/typed_value_test.go
@@ -1,0 +1,311 @@
+package duckdb
+
+import (
+	"database/sql/driver"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type typedIntValuer int
+
+func (v typedIntValuer) Value() (driver.Value, error) {
+	return int64(v), nil
+}
+
+type typedSignedID int64
+
+type typedUnsignedID uint16
+
+type typedErrValuer struct{}
+
+func (typedErrValuer) Value() (driver.Value, error) {
+	return nil, errors.New("typed valuer error")
+}
+
+func TestTypedTimestampNSForComplexPreparedQuery(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	_, err := db.Exec(`
+		CREATE OR REPLACE TABLE events_ns(
+			ts TIMESTAMP_NS,
+			category VARCHAR
+		)
+	`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO events_ns VALUES
+			(TIMESTAMP_NS '2024-04-05 00:00:00.000000001', 'A'),
+			(TIMESTAMP_NS '2024-04-05 01:00:00.000000001', 'A'),
+			(TIMESTAMP_NS '2024-04-05 02:00:00.000000001', 'A'),
+			(TIMESTAMP_NS '2024-04-06 00:00:00.000000001', 'A'),
+			(TIMESTAMP_NS '2024-04-06 01:00:00.000000001', 'A')
+	`)
+	require.NoError(t, err)
+
+	query := `
+		SELECT
+			COALESCE(base.category, cmp.category) AS category,
+			base.metric_value AS metric_value,
+			cmp.metric_value AS metric_value_prev,
+			base.metric_value - cmp.metric_value AS metric_delta
+		FROM (
+			SELECT * FROM (VALUES (?, ?)) t(category, metric_value)
+		) base
+		LEFT JOIN (
+			SELECT category, COUNT(*) AS metric_value
+			FROM events_ns
+			WHERE ts >= ? AND ts < ?
+			  AND category IN (?)
+			GROUP BY 1
+		) cmp
+		ON base.category IS NOT DISTINCT FROM cmp.category
+		ORDER BY metric_value DESC NULLS LAST
+		LIMIT 9
+	`
+	stmt, err := db.Prepare(query)
+	require.NoError(t, err)
+	defer closePreparedWrapper(t, stmt)
+
+	start := time.Date(2024, time.April, 5, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, time.April, 6, 0, 0, 0, 0, time.UTC)
+
+	t.Run("bare time.Time still binds as timestamptz", func(t *testing.T) {
+		var category string
+		var metricValue int
+		var metricValuePrev int64
+		var metricDelta int64
+
+		err := stmt.QueryRow("A", 2, start, end, "A").Scan(
+			&category,
+			&metricValue,
+			&metricValuePrev,
+			&metricDelta,
+		)
+		require.ErrorContains(t, err,
+			"Cannot compare values of type TIMESTAMP_NS and type TIMESTAMP WITH TIME ZONE")
+	})
+
+	t.Run("explicit timestamp_ns wrapper succeeds", func(t *testing.T) {
+		var category string
+		var metricValue int
+		var metricValuePrev int64
+		var metricDelta int64
+
+		err := stmt.QueryRow(
+			"A",
+			2,
+			Typed(start, TYPE_TIMESTAMP_NS),
+			Typed(end, TYPE_TIMESTAMP_NS),
+			"A",
+		).Scan(
+			&category,
+			&metricValue,
+			&metricValuePrev,
+			&metricDelta,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "A", category)
+		require.Equal(t, 2, metricValue)
+		require.EqualValues(t, 3, metricValuePrev)
+		require.EqualValues(t, -1, metricDelta)
+	})
+}
+
+func TestTypedRepresentativeScalars(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	_, err := db.Exec(`SET TimeZone = 'UTC'`)
+	require.NoError(t, err)
+
+	t.Run("integer coerces from default int", func(t *testing.T) {
+		var got int32
+		err := db.QueryRow(`SELECT ?`, Typed(1, TYPE_INTEGER)).Scan(&got)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), got)
+	})
+
+	t.Run("integer accepts named aliases", func(t *testing.T) {
+		var signed int64
+		var unsigned uint32
+		err := db.QueryRow(
+			`SELECT ?, ?`,
+			Typed(typedSignedID(42), TYPE_BIGINT),
+			Typed(typedUnsignedID(7), TYPE_UINTEGER),
+		).Scan(&signed, &unsigned)
+		require.NoError(t, err)
+		require.Equal(t, int64(42), signed)
+		require.Equal(t, uint32(7), unsigned)
+	})
+
+	t.Run("float binds from default float", func(t *testing.T) {
+		var got float32
+		err := db.QueryRow(`SELECT ?`, Typed(1.25, TYPE_FLOAT)).Scan(&got)
+		require.NoError(t, err)
+		require.InDelta(t, 1.25, got, 0.0001)
+	})
+
+	t.Run("float preserves nan and infinities", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			value float64
+			check func(float32) bool
+		}{
+			{name: "nan", value: math.NaN(), check: func(v float32) bool { return math.IsNaN(float64(v)) }},
+			{name: "positive infinity", value: math.Inf(1), check: func(v float32) bool { return math.IsInf(float64(v), 1) }},
+			{name: "negative infinity", value: math.Inf(-1), check: func(v float32) bool { return math.IsInf(float64(v), -1) }},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				var got float32
+				err := db.QueryRow(`SELECT ?`, Typed(tc.value, TYPE_FLOAT)).Scan(&got)
+				require.NoError(t, err)
+				require.True(t, tc.check(got))
+			})
+		}
+	})
+
+	t.Run("timestamp", func(t *testing.T) {
+		want := time.Date(2024, time.April, 5, 12, 34, 56, 123456000, time.UTC)
+		var got time.Time
+		err := db.QueryRow(`SELECT ?`, Typed(want, TYPE_TIMESTAMP)).Scan(&got)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+
+	t.Run("interval", func(t *testing.T) {
+		want := Interval{Days: 10, Months: 4, Micros: 123456}
+		var got Interval
+		err := db.QueryRow(`SELECT ?`, Typed(want, TYPE_INTERVAL)).Scan(&got)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+}
+
+func TestTypedNullAndValuerBinding(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	t.Run("nil binds null", func(t *testing.T) {
+		var got any
+		err := db.QueryRow(`SELECT ?`, Typed(nil, TYPE_INTEGER)).Scan(&got)
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("sqlnull ignores value and valuer", func(t *testing.T) {
+		var got any
+		err := db.QueryRow(`SELECT ?`, Typed(typedErrValuer{}, TYPE_SQLNULL)).Scan(&got)
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("valuer result is coerced", func(t *testing.T) {
+		var got int32
+		err := db.QueryRow(`SELECT ?`, Typed(typedIntValuer(42), TYPE_INTEGER)).Scan(&got)
+		require.NoError(t, err)
+		require.Equal(t, int32(42), got)
+	})
+
+	t.Run("valuer error is returned", func(t *testing.T) {
+		var got any
+		err := db.QueryRow(`SELECT ?`, Typed(typedErrValuer{}, TYPE_INTEGER)).Scan(&got)
+		require.ErrorContains(t, err, "typed valuer error")
+		require.ErrorContains(t, err, "index: 1")
+	})
+
+	t.Run("nil typed value pointer binds null", func(t *testing.T) {
+		var got any
+		var typed *TypedValue
+		err := db.QueryRow(`SELECT ?`, typed).Scan(&got)
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+}
+
+func TestTypedValidation(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	t.Run("unsupported type", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			typ   Type
+			value any
+		}{
+			{name: "list", typ: TYPE_LIST, value: []int32{1}},
+			{name: "decimal", typ: TYPE_DECIMAL, value: Decimal{}},
+			{name: "uuid", typ: TYPE_UUID, value: UUID{}},
+			{name: "blob", typ: TYPE_BLOB, value: []byte{}},
+			{name: "bit", typ: TYPE_BIT, value: Bit{}},
+			{name: "hugeint", typ: TYPE_HUGEINT, value: int64(1)},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				var got any
+				err := db.QueryRow(`SELECT ?`, Typed(tc.value, tc.typ)).Scan(&got)
+				require.ErrorContains(t, err, "unsupported data type: "+typedValueTypeName(tc.typ))
+				require.ErrorContains(t, err, "index: 1")
+			})
+		}
+	})
+
+	t.Run("integer range", func(t *testing.T) {
+		var got any
+		err := db.QueryRow(`SELECT ?`, Typed(256, TYPE_UTINYINT)).Scan(&got)
+		require.ErrorContains(t, err, "cannot convert 256 to UTINYINT")
+		require.ErrorContains(t, err, "index: 1")
+	})
+
+	t.Run("negative integer to unsigned", func(t *testing.T) {
+		var got any
+		err := db.QueryRow(`SELECT ?`, Typed(-1, TYPE_UBIGINT)).Scan(&got)
+		require.ErrorContains(t, err, "cannot convert -1 to UBIGINT")
+		require.ErrorContains(t, err, "index: 1")
+	})
+
+	t.Run("unsigned integer to signed overflow", func(t *testing.T) {
+		var got any
+		err := db.QueryRow(`SELECT ?`, Typed(uint64(math.MaxInt64)+1, TYPE_BIGINT)).Scan(&got)
+		require.ErrorContains(t, err, "cannot convert 9223372036854775808 to BIGINT")
+		require.ErrorContains(t, err, "index: 1")
+	})
+
+	t.Run("integer type mismatch", func(t *testing.T) {
+		var got any
+		err := db.QueryRow(`SELECT ?`, Typed("1", TYPE_INTEGER)).Scan(&got)
+		require.ErrorContains(t, err, "cannot cast string to INTEGER")
+		require.ErrorContains(t, err, "index: 1")
+	})
+
+	t.Run("float32 finite overflow", func(t *testing.T) {
+		var got any
+		err := db.QueryRow(`SELECT ?`, Typed(math.MaxFloat32*2, TYPE_FLOAT)).Scan(&got)
+		require.ErrorContains(t, err, "cannot convert")
+		require.ErrorContains(t, err, "to FLOAT")
+		require.ErrorContains(t, err, "index: 1")
+	})
+
+	t.Run("float32 finite underflow to zero", func(t *testing.T) {
+		var got any
+		err := db.QueryRow(`SELECT ?`, Typed(1e-50, TYPE_FLOAT)).Scan(&got)
+		require.ErrorContains(t, err, "cannot convert")
+		require.ErrorContains(t, err, "to FLOAT")
+		require.ErrorContains(t, err, "index: 1")
+	})
+
+	t.Run("float type mismatch", func(t *testing.T) {
+		var got any
+		err := db.QueryRow(`SELECT ?`, Typed(1, TYPE_DOUBLE)).Scan(&got)
+		require.ErrorContains(t, err, "cannot cast int to DOUBLE")
+		require.ErrorContains(t, err, "index: 1")
+	})
+}


### PR DESCRIPTION
Adds `duckdb.Typed(value, typ)` to force a supported scalar DuckDB type when binding query parameters. This fixes cases where DuckDB cannot infer the desired type, such as `TIMESTAMP_NS` parameters in complex prepared queries where bare `time.Time` would otherwise bind as `TIMESTAMP_TZ`.

refs https://github.com/duckdblabs/duckdb-internal/issues/8812
