### PR TITLE
Eliminate CGO overhead in row scanning hot path

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -73,12 +73,11 @@ func (r *rows) Next(dst []driver.Value) error {
 		r.rowCount = 0
 	}
 
-	columnCount := len(r.chunk.columns)
-	for colIdx := range columnCount {
-		var err error
-		if dst[colIdx], err = r.chunk.GetValue(colIdx, r.rowCount); err != nil {
-			return err
-		}
+	// Call getFn directly, bypassing GetValue/verifyAndRewriteColIdx — indices are
+	// always valid here since we control the chunk lifecycle.
+	rowIdx := mapping.IdxT(r.rowCount)
+	for colIdx := range r.chunk.columns {
+		dst[colIdx] = r.chunk.columns[colIdx].getFn(&r.chunk.columns[colIdx], rowIdx)
 		if bit, ok := dst[colIdx].(Bit); ok {
 			dst[colIdx] = bit.String()
 		}

--- a/vector_getters.go
+++ b/vector_getters.go
@@ -3,6 +3,7 @@ package duckdb
 import (
 	"encoding/json"
 	"math/big"
+	"strings"
 	"time"
 	"unsafe"
 
@@ -12,11 +13,16 @@ import (
 // fnGetVectorValue is the getter callback function for any (nested) vector.
 type fnGetVectorValue func(vec *vector, rowIdx mapping.IdxT) any
 
+// getNull checks DuckDB's validity bitfield: one bit per row packed into uint64 words.
+// Bit = 1 means valid (not null), bit = 0 means null.
 func (vec *vector) getNull(rowIdx mapping.IdxT) bool {
 	if vec.maskPtr == nil {
 		return false
 	}
-	return !mapping.ValidityMaskValueIsValid(vec.maskPtr, rowIdx)
+	entryIdx := uint64(rowIdx) / 64                         // which uint64 word holds this row's bit
+	idxInEntry := uint64(rowIdx) % 64                       // which bit position within that word (0-63)
+	mask := *(*uint64)(unsafe.Add(vec.maskPtr, entryIdx*8)) // read the word at byte offset entryIdx*8
+	return mask&(1<<idxInEntry) == 0                        // 0 = null, 1 = valid
 }
 
 func getPrimitive[T any](vec *vector, rowIdx mapping.IdxT) T {
@@ -168,11 +174,21 @@ func (vec *vector) getBigNum(rowIdx mapping.IdxT) *big.Int {
 
 func (vec *vector) getBytes(rowIdx mapping.IdxT) any {
 	strT := getPrimitive[mapping.StringT](vec, rowIdx)
-	str := mapping.StringTData(&strT)
-	if vec.Type == TYPE_VARCHAR {
-		return str
+	// duckdb_string_t layout: uint32 length at offset 0; if length <= 12 data is inlined
+	// at offset 4, otherwise a pointer at offset 8 (see duckdb.h string_t::INLINE_LENGTH).
+	length := *(*uint32)(unsafe.Pointer(&strT))
+	var data string
+	if length <= 12 {
+		ptr := unsafe.Add(unsafe.Pointer(&strT), 4)
+		data = unsafe.String((*byte)(ptr), int(length))
+	} else {
+		dataPtr := *(*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(&strT), 8))
+		data = unsafe.String((*byte)(dataPtr), int(length))
 	}
-	return []byte(str)
+	if vec.Type == TYPE_VARCHAR {
+		return strings.Clone(data)
+	}
+	return []byte(data)
 }
 
 func (vec *vector) getBit(rowIdx mapping.IdxT) Bit {

--- a/vector_getters.go
+++ b/vector_getters.go
@@ -13,15 +13,15 @@ import (
 // fnGetVectorValue is the getter callback function for any (nested) vector.
 type fnGetVectorValue func(vec *vector, rowIdx mapping.IdxT) any
 
-// getNull checks DuckDB's validity bitfield: one bit per row packed into uint64 words.
+// getNull checks DuckDB's validity bitfield: one bit per row packed into uint64 entries.
 // Bit = 1 means valid (not null), bit = 0 means null.
 func (vec *vector) getNull(rowIdx mapping.IdxT) bool {
 	if vec.maskPtr == nil {
 		return false
 	}
-	entryIdx := uint64(rowIdx) / 64                         // which uint64 word holds this row's bit
-	idxInEntry := uint64(rowIdx) % 64                       // which bit position within that word (0-63)
-	mask := *(*uint64)(unsafe.Add(vec.maskPtr, entryIdx*8)) // read the word at byte offset entryIdx*8
+	entryIdx := uint64(rowIdx) / 64                         // which uint64 entry holds this row's bit
+	idxInEntry := uint64(rowIdx) % 64                       // which bit position within that entry (0-63)
+	mask := *(*uint64)(unsafe.Add(vec.maskPtr, entryIdx*8)) // read the entry at byte offset entryIdx*8
 	return mask&(1<<idxInEntry) == 0                        // 0 = null, 1 = valid
 }
 
@@ -176,6 +176,8 @@ func (vec *vector) getBytes(rowIdx mapping.IdxT) any {
 	strT := getPrimitive[mapping.StringT](vec, rowIdx)
 	// duckdb_string_t layout: uint32 length at offset 0; if length <= 12 data is inlined
 	// at offset 4, otherwise a pointer at offset 8 (see duckdb.h string_t::INLINE_LENGTH).
+	// NOTE: INLINE_LENGTH (12) is not exposed via the C API and could change in a future
+	// DuckDB version. If string tests start failing after a DuckDB upgrade, check here first.
 	length := *(*uint32)(unsafe.Pointer(&strT))
 	var data string
 	if length <= 12 {


### PR DESCRIPTION
## Summary

- Replace per-cell CGO calls in `getNull` and `getBytes` with pure Go pointer arithmetic, reducing ~500K CGO boundary crossings per 1000-row × 250-column query to zero
- Bypass `verifyAndRewriteColIdx` in `rows.Next` by calling `getFn` directly (no bounds/projection check needed on the read path)

## Measured improvement

Single query, 1000 rows × 250 columns, no concurrency:

| Metric | Before | After |
|--------|--------|-------|
| Avg scan time | 16.4ms | 8.1ms |
| Per-row scan | 16.4µs | 8.1µs |

Under 90% CPU pressure (10 concurrent workers):

| Metric | Before | After |
|--------|--------|-------|
| Avg scan time | 432ms | 255ms |
| Max scan time | 1.19s | 622ms |

## Why this matters

Each CGO call pins a goroutine to an OS thread and creates a preemption point. Under CPU contention (70-90%), the OS scheduler delays resumption at each crossing. With 500K crossings per query, even rare preemption events accumulate into multi-second scan stalls in production (observed 1-3s spikes on 32-core pods at 70%+ CPU).

After this change, the scan loop is pure Go — no thread pinning, no preemption points between cells. The goroutine runs uninterrupted through all 250K cells per query.

## Changes

- `vector_getters.go`: `getNull` — inline bit manipulation instead of `mapping.ValidityMaskValueIsValid` CGO call. The validity mask is a `uint64` bitfield already accessible via `vec.maskPtr`; we just read and bit-test it directly.
- `vector_getters.go`: `getBytes` — read `duckdb_string_t` layout directly (uint32 length at offset 0, inlined data at offset 4 for short strings, pointer at offset 8 for long strings) instead of `mapping.StringTData` which made 2 CGO calls (`C.duckdb_string_t_length` + `C.duckdb_string_t_data`) plus `C.GoBytes`.
- `rows.go`: `Next()` — call `getFn` directly on the column vector, skipping `GetValue`/`verifyAndRewriteColIdx` bounds checking (indices are always valid in the rows path).

## Safety

- **Memory lifetime**: `getBytes` uses `strings.Clone` to copy string data to the Go heap before the chunk can be freed (same guarantee as before).
- **Alignment**: `duckdb_string_t` is 16-byte aligned in DuckDB column storage. Reads at offset 0 (uint32) and offset 8 (pointer) are naturally aligned.
- **Validity mask layout**: matches DuckDB's `duckdb_go_bindings_is_valid` implementation exactly (`mask[index/64] & (1 << index%64)`).

## Test plan

- [x] `go test ./...` passes (full test suite including TestTypes, TestBlob, TestBit, TestList, TestMap, TestEnumNullValues, TestEmbeddedNulls, etc.)
- [x] Benchmarked with 1000 rows × 250 columns (142 STRUCT columns, VARCHAR-heavy schema)
- [x] Verified under CPU pressure with 10 concurrent workers on 65 open connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)