### PR TITLE
Support named args in the Arrow interface

### DIFF
--- a/arrow_test.go
+++ b/arrow_test.go
@@ -95,6 +95,33 @@ func TestArrow(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("query table with named args", func(t *testing.T) {
+		c := newConnectorWrapper(t, ``, nil)
+		defer closeConnectorWrapper(t, c)
+
+		innerConn := openDriverConnWrapper(t, c)
+		defer closeDriverConnWrapper(t, &innerConn)
+
+		ar, err := NewArrowFromConn(innerConn)
+		require.NoError(t, err)
+
+		query := `SELECT i FROM (VALUES (1), (2), (3)) t(i) WHERE i > $threshold ORDER BY i`
+		reader, err := ar.QueryContext(context.Background(), query, sql.Named("threshold", 1))
+		require.NoError(t, err)
+		defer reader.Release()
+
+		var values []string
+		for reader.Next() {
+			rec := reader.RecordBatch()
+			col := rec.Column(0)
+			for i := 0; i < col.Len(); i++ {
+				values = append(values, col.ValueStr(i))
+			}
+		}
+		require.NoError(t, reader.Err())
+		require.Equal(t, []string{"2", "3"}, values)
+	})
+
 	t.Run("query error", func(t *testing.T) {
 		err := conn.Raw(func(driverConn any) error {
 			innerConn, ok := driverConn.(driver.Conn)

--- a/statement.go
+++ b/statement.go
@@ -2,6 +2,7 @@ package duckdb
 
 import (
 	"context"
+	"database/sql"
 	"database/sql/driver"
 	"errors"
 	"fmt"
@@ -794,6 +795,10 @@ func (s *Stmt) executeBound(ctx context.Context) (*mapping.Result, error) {
 func argsToNamedArgs(values []driver.Value) []driver.NamedValue {
 	args := make([]driver.NamedValue, len(values))
 	for n, param := range values {
+		if np, ok := param.(sql.NamedArg); ok {
+			args[n].Name = np.Name
+			param = np.Value
+		}
 		args[n].Value = param
 		args[n].Ordinal = n + 1
 	}


### PR DESCRIPTION
I noticed while working with the arrow interface that passing named args does not seem to be supported at the moment.

This PR unwraps sql.NamedArg in argsToNamedArgs, populating driver.NamedValue.Name. This is how Go's `database/sql` builds driver.NamedValue internally.

Only the arrow context is affected, as it doesn't use `database/sql` directly.