### PR TITLE
fix: resolve checkptr misaligned pointer conversion under Go 1.26 -race

### DIFF
--- a/vector_getters.go
+++ b/vector_getters.go
@@ -184,7 +184,8 @@ func (vec *vector) getBytes(rowIdx mapping.IdxT) any {
 		ptr := unsafe.Add(unsafe.Pointer(&strT), 4)
 		data = unsafe.String((*byte)(ptr), int(length))
 	} else {
-		dataPtr := *(*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(&strT), 8))
+		var dataPtr unsafe.Pointer
+		copy(unsafe.Slice((*byte)(unsafe.Pointer(&dataPtr)), 8), unsafe.Slice((*byte)(unsafe.Add(unsafe.Pointer(&strT), 8)), 8))
 		data = unsafe.String((*byte)(dataPtr), int(length))
 	}
 	if vec.Type == TYPE_VARCHAR {


### PR DESCRIPTION
In v2.10503.1, direct Go-side pointer arithmetic was introduced in `vector_getters.go:187` to avoid Cgo overhead when reading VARCHAR columns. However, this casts an unaligned stack address to `*unsafe.Pointer`, triggering a `fatal error: checkptr: misaligned pointer conversion` under Go 1.26's strict alignment checks with the race detector enabled. This PR resolves the alignment check panic by copying the pointer's bytes to an aligned local variable using `copy` instead of doing a misaligned pointer conversion.