### PR TITLE
Add JSON marshal/unmarshal for OrderedMap

### DIFF
--- a/types.go
+++ b/types.go
@@ -272,34 +272,6 @@ func (b Bit) String() string {
 	return sb.String()
 }
 
-// MarshalJSON encodes the bit as a JSON string of '0'/'1' characters (e.g. "10110001").
-// Zero-length and nil bits both marshal to JSON null.
-func (b Bit) MarshalJSON() ([]byte, error) {
-	if b.Len() == 0 {
-		return []byte("null"), nil
-	}
-	return json.Marshal(b.String())
-}
-
-// UnmarshalJSON decodes a JSON string of '0'/'1' characters produced by MarshalJSON.
-// JSON null resets the bit to nil.
-func (b *Bit) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" {
-		b.Data = nil
-		return nil
-	}
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
-	}
-	bit, err := NewBitFromString(s)
-	if err != nil {
-		return err
-	}
-	*b = bit
-	return nil
-}
-
 func hugeIntToNative(hugeInt *mapping.HugeInt) *big.Int {
 	lower, upper := mapping.HugeIntMembers(hugeInt)
 	i := big.NewInt(upper)
@@ -729,7 +701,6 @@ func (s *Composite[T]) Scan(v any) error {
 
 const max_decimal_width = 38
 
-//nolint:recvcheck // MarshalJSON uses a value receiver; UnmarshalJSON requires a pointer receiver.
 type Decimal struct {
 	Width uint8
 	Scale uint8
@@ -747,7 +718,7 @@ func (d Decimal) Float64() float64 {
 
 func (d Decimal) String() string {
 	// Get the sign, and return early, if zero.
-	if d.Value == nil || d.Value.Sign() == 0 {
+	if d.Value.Sign() == 0 {
 		return "0"
 	}
 
@@ -773,58 +744,6 @@ func (d Decimal) String() string {
 		return fmt.Sprintf("%s0.%s%s", signStr, strings.Repeat("0", scale-len(zeroTrimmed)), zeroTrimmed)
 	}
 	return signStr + zeroTrimmed[:len(zeroTrimmed)-scale] + "." + zeroTrimmed[len(zeroTrimmed)-scale:]
-}
-
-// MarshalJSON encodes the decimal as a canonical decimal string (e.g. "1.23").
-// A nil Value marshals to JSON null, matching UnmarshalJSON's null handling and making
-// the nil round-trip symmetric: nil → null → nil.
-// Trailing zeros are stripped by String(), so Scale and Width are not fully preserved:
-// Decimal{Scale:2, Value:100} marshals to "1", not "1.00".
-func (d Decimal) MarshalJSON() ([]byte, error) {
-	if d.Value == nil {
-		return []byte("null"), nil
-	}
-	return json.Marshal(d.String())
-}
-
-// UnmarshalJSON decodes a canonical decimal string produced by MarshalJSON.
-// Scale is inferred from the number of fractional digits; Width is set to 0 (not
-// encoded). Trailing zeros stripped by MarshalJSON are not restored, so a round-trip
-// through JSON is value-preserving but not struct-equal. JSON null resets all fields.
-// Returns an error if the input has more than 255 fractional digits.
-func (d *Decimal) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" {
-		d.Value = nil
-		d.Scale = 0
-		d.Width = 0
-		return nil
-	}
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
-	}
-	dotIdx := strings.IndexByte(s, '.')
-	var intStr string
-	var scale uint8
-	if dotIdx == -1 {
-		intStr = s
-	} else {
-		fracDigits := len(s) - dotIdx - 1
-		if fracDigits > 255 {
-			return fmt.Errorf("decimal has %d fractional digits, max 255", fracDigits)
-		}
-		scale = uint8(fracDigits)
-		intStr = s[:dotIdx] + s[dotIdx+1:]
-	}
-	value := new(big.Int)
-	if _, ok := value.SetString(intStr, 10); !ok {
-		return fmt.Errorf("invalid decimal value: %s", s)
-	}
-	d.Value = value
-	d.Scale = scale
-	// Width is not encoded in the string representation.
-	d.Width = 0
-	return nil
 }
 
 type Union struct {

--- a/types.go
+++ b/types.go
@@ -1,9 +1,11 @@
 package duckdb
 
 import (
+	"bytes"
 	"database/sql/driver"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -270,6 +272,34 @@ func (b Bit) String() string {
 	return sb.String()
 }
 
+// MarshalJSON encodes the bit as a JSON string of '0'/'1' characters (e.g. "10110001").
+// Zero-length and nil bits both marshal to JSON null.
+func (b Bit) MarshalJSON() ([]byte, error) {
+	if b.Len() == 0 {
+		return []byte("null"), nil
+	}
+	return json.Marshal(b.String())
+}
+
+// UnmarshalJSON decodes a JSON string of '0'/'1' characters produced by MarshalJSON.
+// JSON null resets the bit to nil.
+func (b *Bit) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		b.Data = nil
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	bit, err := NewBitFromString(s)
+	if err != nil {
+		return err
+	}
+	*b = bit
+	return nil
+}
+
 func hugeIntToNative(hugeInt *mapping.HugeInt) *big.Int {
 	lower, upper := mapping.HugeIntMembers(hugeInt)
 	i := big.NewInt(upper)
@@ -511,7 +541,10 @@ func (m *Map) Scan(v any) error {
 // NOTE: only supports keys of comparable types (no slices, maps, or functions).
 // NOTE: Set and Get use linear search, so performance may degrade with large maps.
 //
-//nolint:recvcheck
+// Value receivers on MarshalJSON/String let plain OrderedMap values satisfy
+// json.Marshaler/fmt.Stringer; Set/Delete/Scan/UnmarshalJSON need pointer receivers.
+//
+//nolint:recvcheck // value + pointer receivers are intentional (see above)
 type OrderedMap struct {
 	keys   []any
 	values []any
@@ -583,6 +616,79 @@ func (om *OrderedMap) Scan(v any) error {
 	return nil
 }
 
+// MarshalJSON encodes the map as a JSON object preserving insertion order.
+// Non-string keys are stringified via fmt.Sprintf; they are not recoverable on unmarshal
+// (UnmarshalJSON always produces string keys). Nested OrderedMap values are also not
+// preserved: they re-encode correctly but decode back as map[string]any.
+func (om OrderedMap) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, key := range om.keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		keyBytes, err := json.Marshal(key)
+		if err != nil {
+			return nil, err
+		}
+		// JSON object keys must be strings; wrap non-string keys.
+		if len(keyBytes) == 0 || keyBytes[0] != '"' {
+			keyBytes, err = json.Marshal(fmt.Sprintf("%v", key))
+			if err != nil {
+				return nil, err
+			}
+		}
+		buf.Write(keyBytes)
+		buf.WriteByte(':')
+		valBytes, err := json.Marshal(om.values[i])
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(valBytes)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// UnmarshalJSON decodes a JSON object into the map, preserving the key order from the
+// JSON stream. All keys are decoded as strings; numeric/other key types are not restored.
+// JSON null resets the map to empty.
+func (om *OrderedMap) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		om.keys = nil
+		om.values = nil
+		return nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	t, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if delim, ok := t.(json.Delim); !ok || delim != '{' {
+		return fmt.Errorf("expected JSON object, got %v", t)
+	}
+	om.keys = nil
+	om.values = nil
+	for dec.More() {
+		t, err = dec.Token()
+		if err != nil {
+			return err
+		}
+		key, ok := t.(string)
+		if !ok {
+			return fmt.Errorf("expected string key, got %T", t)
+		}
+		var val any
+		if err = dec.Decode(&val); err != nil {
+			return err
+		}
+		om.keys = append(om.keys, key)
+		om.values = append(om.values, val)
+	}
+	_, err = dec.Token() // closing '}'
+	return err
+}
+
 func mapKeysField() string {
 	return "key"
 }
@@ -623,6 +729,7 @@ func (s *Composite[T]) Scan(v any) error {
 
 const max_decimal_width = 38
 
+//nolint:recvcheck // MarshalJSON uses a value receiver; UnmarshalJSON requires a pointer receiver.
 type Decimal struct {
 	Width uint8
 	Scale uint8
@@ -640,7 +747,7 @@ func (d Decimal) Float64() float64 {
 
 func (d Decimal) String() string {
 	// Get the sign, and return early, if zero.
-	if d.Value.Sign() == 0 {
+	if d.Value == nil || d.Value.Sign() == 0 {
 		return "0"
 	}
 
@@ -666,6 +773,58 @@ func (d Decimal) String() string {
 		return fmt.Sprintf("%s0.%s%s", signStr, strings.Repeat("0", scale-len(zeroTrimmed)), zeroTrimmed)
 	}
 	return signStr + zeroTrimmed[:len(zeroTrimmed)-scale] + "." + zeroTrimmed[len(zeroTrimmed)-scale:]
+}
+
+// MarshalJSON encodes the decimal as a canonical decimal string (e.g. "1.23").
+// A nil Value marshals to JSON null, matching UnmarshalJSON's null handling and making
+// the nil round-trip symmetric: nil → null → nil.
+// Trailing zeros are stripped by String(), so Scale and Width are not fully preserved:
+// Decimal{Scale:2, Value:100} marshals to "1", not "1.00".
+func (d Decimal) MarshalJSON() ([]byte, error) {
+	if d.Value == nil {
+		return []byte("null"), nil
+	}
+	return json.Marshal(d.String())
+}
+
+// UnmarshalJSON decodes a canonical decimal string produced by MarshalJSON.
+// Scale is inferred from the number of fractional digits; Width is set to 0 (not
+// encoded). Trailing zeros stripped by MarshalJSON are not restored, so a round-trip
+// through JSON is value-preserving but not struct-equal. JSON null resets all fields.
+// Returns an error if the input has more than 255 fractional digits.
+func (d *Decimal) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		d.Value = nil
+		d.Scale = 0
+		d.Width = 0
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	dotIdx := strings.IndexByte(s, '.')
+	var intStr string
+	var scale uint8
+	if dotIdx == -1 {
+		intStr = s
+	} else {
+		fracDigits := len(s) - dotIdx - 1
+		if fracDigits > 255 {
+			return fmt.Errorf("decimal has %d fractional digits, max 255", fracDigits)
+		}
+		scale = uint8(fracDigits)
+		intStr = s[:dotIdx] + s[dotIdx+1:]
+	}
+	value := new(big.Int)
+	if _, ok := value.SetString(intStr, 10); !ok {
+		return fmt.Errorf("invalid decimal value: %s", s)
+	}
+	d.Value = value
+	d.Scale = scale
+	// Width is not encoded in the string representation.
+	d.Width = 0
+	return nil
 }
 
 type Union struct {

--- a/types_test.go
+++ b/types_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -1641,4 +1642,133 @@ func TestGeometry(t *testing.T) {
 	// We expect Geography/Geometry to come back as a native binary BLOB map
 	require.NotEmpty(t, res)
 	require.False(t, r.Next())
+}
+
+// TestIntervalJSON checks that Interval marshals to/from {"days":N,"months":N,"micros":N}.
+func TestIntervalJSON(t *testing.T) {
+	i := Interval{Days: 5, Months: 2, Micros: 1000}
+
+	data, err := json.Marshal(i)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"days":5,"months":2,"micros":1000}`, string(data))
+
+	var got Interval
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, i, got)
+}
+
+// TestBitJSON checks that Bit marshals to/from a bit string (e.g. "10110001"),
+// not as a base64-encoded byte array.
+func TestBitJSON(t *testing.T) {
+	b, err := NewBitFromString("10110001")
+	require.NoError(t, err)
+
+	data, err := json.Marshal(b)
+	require.NoError(t, err)
+	require.Equal(t, `"10110001"`, string(data))
+
+	var got Bit
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, b, got)
+}
+
+// TestJSONNullRoundtrip checks that unmarshaling JSON null resets each type to its zero
+// state and does not error — consistent with how encoding/json handles nullable types.
+func TestJSONNullRoundtrip(t *testing.T) {
+	t.Run("Bit", func(t *testing.T) {
+		b, err := NewBitFromString("101")
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal([]byte("null"), &b))
+		require.Nil(t, b.Data)
+	})
+
+	t.Run("Decimal", func(t *testing.T) {
+		d := Decimal{Width: 18, Scale: 2, Value: big.NewInt(123)}
+		require.NoError(t, json.Unmarshal([]byte("null"), &d))
+		require.Nil(t, d.Value)
+	})
+
+	t.Run("OrderedMap", func(t *testing.T) {
+		om := OrderedMap{}
+		om.Set("k", float64(1))
+		require.NoError(t, json.Unmarshal([]byte("null"), &om))
+		require.Equal(t, 0, om.Len())
+	})
+}
+
+// TestBitJSONEmpty checks that a non-nil but zero-length Bit round-trips through JSON
+// without error. Previously MarshalJSON emitted "" which UnmarshalJSON rejected.
+func TestBitJSONEmpty(t *testing.T) {
+	cases := []Bit{
+		{Data: []byte{}},
+		{Data: []byte{0}}, // valid encoding: padding=0, no bit data
+	}
+	for _, b := range cases {
+		data, err := json.Marshal(b)
+		require.NoError(t, err)
+		var got Bit
+		require.NoError(t, json.Unmarshal(data, &got))
+		require.Equal(t, 0, got.Len())
+	}
+}
+
+// TestDecimalJSONNilValue checks that a nil-Value Decimal marshals to null and
+// round-trips symmetrically: nil Value → null → nil Value.
+func TestDecimalJSONNilValue(t *testing.T) {
+	d := Decimal{Width: 18, Scale: 2, Value: nil}
+
+	data, err := json.Marshal(d)
+	require.NoError(t, err)
+	require.Equal(t, `null`, string(data))
+
+	var got Decimal
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Nil(t, got.Value)
+}
+
+// TestDecimalJSON checks that Decimal marshals to/from its decimal string representation
+// (e.g. "1.23"), not as a struct with Width/Scale/Value fields.
+func TestDecimalJSON(t *testing.T) {
+	d := Decimal{Width: 18, Scale: 2, Value: big.NewInt(123)}
+
+	data, err := json.Marshal(d)
+	require.NoError(t, err)
+	require.Equal(t, `"1.23"`, string(data))
+
+	var got Decimal
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, d.String(), got.String())
+}
+
+// TestUnionJSON checks that Union marshals to/from {"tag":"...","value":...}.
+func TestUnionJSON(t *testing.T) {
+	u := Union{Tag: "int32", Value: int32(42)}
+
+	data, err := json.Marshal(u)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"tag":"int32","value":42}`, string(data))
+
+	var got Union
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, u.Tag, got.Tag)
+	// JSON numbers unmarshal as float64 when the target is any/driver.Value.
+	require.Equal(t, float64(42), got.Value)
+}
+
+// TestOrderedMapJSON checks that OrderedMap marshals to a JSON object preserving
+// insertion order, not as an empty object (which would happen with unexported fields).
+func TestOrderedMapJSON(t *testing.T) {
+	om := OrderedMap{}
+	om.Set("b", float64(2))
+	om.Set("a", float64(1))
+
+	data, err := json.Marshal(om)
+	require.NoError(t, err)
+	// Keys must appear in insertion order.
+	require.Equal(t, `{"b":2,"a":1}`, string(data))
+
+	var got OrderedMap
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, om.Keys(), got.Keys())
+	require.Equal(t, om.Values(), got.Values())
 }

--- a/types_test.go
+++ b/types_test.go
@@ -1657,87 +1657,15 @@ func TestIntervalJSON(t *testing.T) {
 	require.Equal(t, i, got)
 }
 
-// TestBitJSON checks that Bit marshals to/from a bit string (e.g. "10110001"),
-// not as a base64-encoded byte array.
-func TestBitJSON(t *testing.T) {
-	b, err := NewBitFromString("10110001")
-	require.NoError(t, err)
-
-	data, err := json.Marshal(b)
-	require.NoError(t, err)
-	require.Equal(t, `"10110001"`, string(data))
-
-	var got Bit
-	require.NoError(t, json.Unmarshal(data, &got))
-	require.Equal(t, b, got)
-}
-
-// TestJSONNullRoundtrip checks that unmarshaling JSON null resets each type to its zero
+// TestJSONNullRoundtrip checks that unmarshaling JSON null resets OrderedMap to its zero
 // state and does not error — consistent with how encoding/json handles nullable types.
 func TestJSONNullRoundtrip(t *testing.T) {
-	t.Run("Bit", func(t *testing.T) {
-		b, err := NewBitFromString("101")
-		require.NoError(t, err)
-		require.NoError(t, json.Unmarshal([]byte("null"), &b))
-		require.Nil(t, b.Data)
-	})
-
-	t.Run("Decimal", func(t *testing.T) {
-		d := Decimal{Width: 18, Scale: 2, Value: big.NewInt(123)}
-		require.NoError(t, json.Unmarshal([]byte("null"), &d))
-		require.Nil(t, d.Value)
-	})
-
 	t.Run("OrderedMap", func(t *testing.T) {
 		om := OrderedMap{}
 		om.Set("k", float64(1))
 		require.NoError(t, json.Unmarshal([]byte("null"), &om))
 		require.Equal(t, 0, om.Len())
 	})
-}
-
-// TestBitJSONEmpty checks that a non-nil but zero-length Bit round-trips through JSON
-// without error. Previously MarshalJSON emitted "" which UnmarshalJSON rejected.
-func TestBitJSONEmpty(t *testing.T) {
-	cases := []Bit{
-		{Data: []byte{}},
-		{Data: []byte{0}}, // valid encoding: padding=0, no bit data
-	}
-	for _, b := range cases {
-		data, err := json.Marshal(b)
-		require.NoError(t, err)
-		var got Bit
-		require.NoError(t, json.Unmarshal(data, &got))
-		require.Equal(t, 0, got.Len())
-	}
-}
-
-// TestDecimalJSONNilValue checks that a nil-Value Decimal marshals to null and
-// round-trips symmetrically: nil Value → null → nil Value.
-func TestDecimalJSONNilValue(t *testing.T) {
-	d := Decimal{Width: 18, Scale: 2, Value: nil}
-
-	data, err := json.Marshal(d)
-	require.NoError(t, err)
-	require.Equal(t, `null`, string(data))
-
-	var got Decimal
-	require.NoError(t, json.Unmarshal(data, &got))
-	require.Nil(t, got.Value)
-}
-
-// TestDecimalJSON checks that Decimal marshals to/from its decimal string representation
-// (e.g. "1.23"), not as a struct with Width/Scale/Value fields.
-func TestDecimalJSON(t *testing.T) {
-	d := Decimal{Width: 18, Scale: 2, Value: big.NewInt(123)}
-
-	data, err := json.Marshal(d)
-	require.NoError(t, err)
-	require.Equal(t, `"1.23"`, string(data))
-
-	var got Decimal
-	require.NoError(t, json.Unmarshal(data, &got))
-	require.Equal(t, d.String(), got.String())
 }
 
 // TestUnionJSON checks that Union marshals to/from {"tag":"...","value":...}.


### PR DESCRIPTION
## Summary

- **OrderedMap**: `MarshalJSON`/`UnmarshalJSON` encode as a JSON object preserving insertion order. This fixes a silent data-loss bug where marshaling produced `{}`, dropping all keys and values.

Null handling is symmetric: an empty map marshals to `{}`, and unmarshaling `null` resets the map to empty without error.

## Behavioral note: JSON-column write representation changed

`setJSON` calls `json.Marshal(val)`, so binding an `OrderedMap` into a DuckDB `JSON` column now produces different bytes:

| Before | After |
|---|---|
| `{}` (all data silently dropped) | `{"k1":v1,"k2":v2}` |

This is a bug fix. Existing JSON columns that stored `OrderedMap` values will contain empty objects written by the old code; new rows will have the correct data.

## Test plan

- [ ] `TestOrderedMapJSON` — ordered object with insertion-order keys, full round-trip
- [ ] `TestJSONNullRoundtrip/OrderedMap` — `null` resets map to empty without error
- [ ] `TestIntervalJSON` / `TestUnionJSON` — characterization tests confirming existing struct-tag marshaling is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)