### PR TITLE
Fix checkptr misalignment in getBytes for non-inlined strings

### DIFF
--- a/types_test.go
+++ b/types_test.go
@@ -770,6 +770,65 @@ func TestBlob(t *testing.T) {
 	require.Equal(t, []byte{0xAA}, b)
 }
 
+// TestVarcharBoundary covers the inlined (≤12 chars) and non-inlined (>12 chars) paths
+// in getBytes, including the exact boundary and the alignment-sensitive pointer read.
+func TestVarcharBoundary(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	tests := []struct {
+		name string
+		val  string
+	}{
+		{"empty", ""},
+		{"one char", "a"},
+		{"inlined max (12)", "123456789012"},
+		{"non-inlined min (13)", "1234567890123"},
+		{"long", "this is a much longer string that is definitely not inlined"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			require.NoError(t, db.QueryRow("SELECT ?::VARCHAR", tc.val).Scan(&got))
+			require.Equal(t, tc.val, got)
+		})
+	}
+}
+
+// TestBlobBoundary mirrors TestVarcharBoundary for the BLOB type,
+// which shares the same getBytes path but returns []byte.
+func TestBlobBoundary(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	createTable(t, db, `CREATE TABLE blob_boundary (data BLOB)`)
+
+	tests := []struct {
+		name string
+		val  []byte
+	}{
+		{"empty", []byte{}},
+		{"inlined max (12)", bytes.Repeat([]byte{0xFF}, 12)},
+		{"non-inlined min (13)", bytes.Repeat([]byte{0xFF}, 13)},
+		{"long", bytes.Repeat([]byte{0xAB}, 64)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := db.Exec("INSERT INTO blob_boundary VALUES (?)", tc.val)
+			require.NoError(t, err)
+
+			var got []byte
+			require.NoError(t, db.QueryRow("SELECT data FROM blob_boundary WHERE data = ?", tc.val).Scan(&got))
+			require.Equal(t, tc.val, got)
+
+			_, err = db.Exec("DELETE FROM blob_boundary")
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestList(t *testing.T) {
 	db := openDbWrapper(t, ``)
 	defer closeDbWrapper(t, db)

--- a/vector_getters.go
+++ b/vector_getters.go
@@ -173,18 +173,24 @@ func (vec *vector) getBigNum(rowIdx mapping.IdxT) *big.Int {
 }
 
 func (vec *vector) getBytes(rowIdx mapping.IdxT) any {
-	strT := getPrimitive[mapping.StringT](vec, rowIdx)
+	// Use a pointer directly into C-allocated vector memory rather than a stack copy.
+	// cgo declares duckdb_string_t with alignment 1, so a stack copy (via getPrimitive)
+	// may land at an odd address. Reading the out-of-line pointer field at offset 8
+	// then requires 8-byte alignment, which trips checkptr under -race.
+	// C's allocator guarantees vec.dataPtr is ≥8-byte aligned, and each
+	// duckdb_string_t is 16 bytes, so offset 8 within any element is always 8-byte aligned.
+	strTPtr := (*mapping.StringT)(unsafe.Add(vec.dataPtr, uintptr(rowIdx)*unsafe.Sizeof(mapping.StringT{})))
+	length := *(*uint32)(unsafe.Pointer(strTPtr))
 	// duckdb_string_t layout: uint32 length at offset 0; if length <= 12 data is inlined
 	// at offset 4, otherwise a pointer at offset 8 (see duckdb.h string_t::INLINE_LENGTH).
 	// NOTE: INLINE_LENGTH (12) is not exposed via the C API and could change in a future
 	// DuckDB version. If string tests start failing after a DuckDB upgrade, check here first.
-	length := *(*uint32)(unsafe.Pointer(&strT))
 	var data string
 	if length <= 12 {
-		ptr := unsafe.Add(unsafe.Pointer(&strT), 4)
+		ptr := unsafe.Add(unsafe.Pointer(strTPtr), 4)
 		data = unsafe.String((*byte)(ptr), int(length))
 	} else {
-		dataPtr := *(*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(&strT), 8))
+		dataPtr := *(*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(strTPtr), 8))
 		data = unsafe.String((*byte)(dataPtr), int(length))
 	}
 	if vec.Type == TYPE_VARCHAR {


### PR DESCRIPTION
## Problem

Scanning a VARCHAR or BLOB longer than 12 characters crashes with `fatal error: checkptr: misaligned pointer conversion` when built with `-race` (reported in #142).

`getBytes` calls `getPrimitive` which copies `duckdb_string_t` from C memory onto the Go stack. Since cgo declares the type with alignment 1, Go may place the copy at any stack address. Reading the out-of-line pointer field at offset 8 then requires an 8-byte-aligned address, which is not guaranteed for the stack copy — tripping checkptr.

## Fix

Work with a pointer directly into the C-allocated vector buffer (`vec.dataPtr`) instead of a stack copy. The C allocator guarantees `vec.dataPtr` is ≥8-byte aligned, and each `duckdb_string_t` is 16 bytes, so offset 8 within any element is always 8-byte aligned. This preserves the zero-CGO reads from #141.

## Tests

Added `TestVarcharBoundary` and `TestBlobBoundary` covering the inlined (≤12 chars) and non-inlined (>12 chars) paths, including the exact boundary values.

Closes #142