### PR TITLE
Fix connector and appender cleanup edge cases

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -296,7 +296,8 @@ func (a *Appender) Flush() error {
 // FlushWithCancel flushes the data chunks to the underlying table and clears the internal cache.
 // Does not close the appender, even if it returns an error. Unless you have a good reason to call this,
 // call CloseWithCancel when you are done with the appender.
-// Takes a context for cancellation.
+// Takes a context for cancellation. Unlike query execution, an already-canceled ctx does not
+// skip starting the flush, but that flush may be interrupted immediately.
 func (a *Appender) FlushWithCancel(ctx context.Context) error {
 	if err := a.appendDataChunk(); err != nil {
 		return getError(errAppenderFlush, invalidatedAppenderError(err))
@@ -314,17 +315,20 @@ func (a *Appender) FlushWithCancel(ctx context.Context) error {
 // Clear is typically used after an error occurs during Flush or FlushWithCancel to avoid memory leaks
 // before closing the appender. After calling Clear, the appender can be reused for appending new rows.
 func (a *Appender) Clear() error {
-	var errClear error
-	if mapping.AppenderClear(a.appender) == mapping.StateError {
-		errClear = getDuckDBError(mapping.AppenderError(a.appender))
-	}
-
+	errClear := a.clearAppender()
 	a.chunk.reset(true)
 	a.rowCount = 0
 
-	if errClear != nil {
+	return errClear
+}
+
+// clearAppender clears only DuckDB's appender state; it does not touch the Go chunk buffer.
+func (a *Appender) clearAppender() error {
+	if mapping.AppenderClear(a.appender) == mapping.StateError {
+		errClear := getDuckDBError(mapping.AppenderError(a.appender))
 		return getError(invalidatedAppenderClearError(errClear), nil)
 	}
+
 	return nil
 }
 
@@ -337,7 +341,7 @@ func (a *Appender) Close() error {
 // CloseWithCancel closes the appender. This flushes any remaining data chunks to the underlying table.
 // The flush operation can be cancelled via the provided context. If the flush fails, the appender is cleared
 // before closing to prevent a memory leak. It is essential to call this function when you are done with
-// the appender to avoid leaking memory.
+// the appender to avoid leaking memory. It uses the same cancellation behavior as FlushWithCancel.
 func (a *Appender) CloseWithCancel(ctx context.Context) error {
 	if a.closed {
 		return getError(errAppenderDoubleClose, nil)
@@ -353,7 +357,7 @@ func (a *Appender) CloseWithCancel(ctx context.Context) error {
 
 	var errClear error
 	if errFlush != nil {
-		errClear = a.Clear()
+		errClear = a.clearAppender()
 	}
 	// Destroy all appender data and the appender.
 	destroyLogicalTypes(a.types)
@@ -461,7 +465,8 @@ func (a *Appender) flushWithCancel(ctx context.Context) error {
 	mainDoneCh := make(chan struct{})
 	bgDoneCh := make(chan struct{})
 
-	// Spawn go-routine waiting to receive on the context or main channel.
+	// Appender cancellation always starts the flush, even if ctx is already
+	// canceled. The background routine may interrupt the flush immediately.
 	go interruptRoutine(&mainDoneCh, &bgDoneCh, ctx, a.conn)
 
 	state := mapping.AppenderFlush(a.appender)

--- a/appender_cancel_test.go
+++ b/appender_cancel_test.go
@@ -1,0 +1,212 @@
+package duckdb
+
+import (
+	"context"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/duckdb/duckdb-go/v2/mapping"
+)
+
+type appenderSpies struct {
+	flush                bool
+	clear                bool
+	destroyAppenderCalls int
+	destroyChunkCalls    int
+	resetChunk           bool
+	getChunkVector       bool
+}
+
+// stubAppenderMapping installs no-op/spy mapping hooks for appender cancellation tests.
+func stubAppenderMapping(t *testing.T, flushState mapping.State, appenderErr string) *appenderSpies {
+	t.Helper()
+
+	spies := &appenderSpies{}
+	patchVar(t, &mapping.Interrupt, func(_ mapping.Connection) {})
+
+	// Spy hooks record the appender and chunk operations under test.
+	patchVar(t, &mapping.AppenderFlush, func(_ mapping.Appender) mapping.State {
+		spies.flush = true
+		return flushState
+	})
+	patchVar(t, &mapping.AppenderError, func(_ mapping.Appender) string {
+		return appenderErr
+	})
+	patchVar(t, &mapping.AppenderClear, func(_ mapping.Appender) mapping.State {
+		spies.clear = true
+		return mapping.StateSuccess
+	})
+	patchVar(t, &mapping.AppenderDestroy, func(_ *mapping.Appender) mapping.State {
+		spies.destroyAppenderCalls++
+		return mapping.StateSuccess
+	})
+	patchVar(t, &mapping.DestroyDataChunk, func(_ *mapping.DataChunk) {
+		spies.destroyChunkCalls++
+	})
+	patchVar(t, &mapping.DataChunkReset, func(_ mapping.DataChunk) {
+		spies.resetChunk = true
+	})
+
+	// Safety no-ops keep fake handles away from the C API if chunk reset is reached.
+	patchVar(t, &mapping.DataChunkSetSize, func(_ mapping.DataChunk, _ mapping.IdxT) {})
+	patchVar(t, &mapping.DataChunkGetVector, func(_ mapping.DataChunk, _ mapping.IdxT) mapping.Vector {
+		spies.getChunkVector = true
+		return mapping.Vector{}
+	})
+	patchVar(t, &mapping.VectorGetData, func(_ mapping.Vector) unsafe.Pointer {
+		return nil
+	})
+	patchVar(t, &mapping.VectorEnsureValidityWritable, func(_ mapping.Vector) {})
+	patchVar(t, &mapping.VectorGetValidity, func(_ mapping.Vector) unsafe.Pointer {
+		return nil
+	})
+	return spies
+}
+
+func newStubAppender() *Appender {
+	return &Appender{
+		conn: &Conn{},
+	}
+}
+
+func preCanceledContext() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}
+
+// The tests below patch package-level mapping hooks and must not run in parallel.
+func TestAppenderFlushWithCancelPreCanceledAttemptsFlush(t *testing.T) {
+	// This characterizes the fast success path; failure and interrupt handling are covered below.
+	spies := stubAppenderMapping(t, mapping.StateSuccess, "")
+
+	ctx := preCanceledContext()
+	a := newStubAppender()
+
+	require.NoError(t, a.flushWithCancel(ctx))
+	require.True(t, spies.flush, "AppenderFlush should run when ctx is pre-canceled")
+}
+
+func TestAppenderCloseWithCancelPreCanceledFlushesAndCleansUp(t *testing.T) {
+	// This characterizes the fast success path; failure and interrupt handling are covered below.
+	spies := stubAppenderMapping(t, mapping.StateSuccess, "")
+
+	ctx := preCanceledContext()
+	a := newStubAppender()
+
+	require.NoError(t, a.CloseWithCancel(ctx))
+	require.True(t, spies.flush, "AppenderFlush should run when ctx is pre-canceled")
+	require.False(t, spies.clear, "successful pre-canceled close should not clear flushed appender state")
+	require.Equal(t, 1, spies.destroyAppenderCalls, "pre-canceled close should destroy the appender")
+	require.Equal(t, 1, spies.destroyChunkCalls, "pre-canceled close should destroy the data chunk")
+}
+
+func TestAppenderFlushWithCancelPreCanceledFailureIncludesContext(t *testing.T) {
+	spies := stubAppenderMapping(t, mapping.StateError, "Invalid Input Error: appender failed")
+
+	ctx := preCanceledContext()
+	a := newStubAppender()
+
+	err := a.flushWithCancel(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorContains(t, err, "appender failed")
+
+	err = a.FlushWithCancel(ctx)
+	require.ErrorIs(t, err, errAppenderFlush)
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorContains(t, err, "appender failed")
+	require.True(t, spies.flush, "AppenderFlush should run when ctx is pre-canceled")
+}
+
+func TestAppenderCloseWithCancelFlushFailureClearsWithoutResettingChunk(t *testing.T) {
+	spies := stubAppenderMapping(t, mapping.StateError, "Invalid Input Error: appender failed")
+
+	ctx := preCanceledContext()
+	a := newStubAppender()
+	a.chunk.columns = make([]vector, 1)
+
+	err := a.CloseWithCancel(ctx)
+	require.ErrorIs(t, err, errAppenderClose)
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorContains(t, err, "appender failed")
+	require.True(t, spies.clear, "failed close should clear buffered appender state")
+	require.False(t, spies.resetChunk, "failed close should not reset the destroyed data chunk")
+	require.False(t, spies.getChunkVector, "failed close should not reinitialize vectors on the destroyed data chunk")
+}
+
+func TestAppenderCloseWithCancelFlushAndClearFailuresAreJoined(t *testing.T) {
+	spies := stubAppenderMapping(t, mapping.StateError, "Invalid Input Error: flush failed")
+
+	var appenderErrorCalls int
+	patchVar(t, &mapping.AppenderError, func(_ mapping.Appender) string {
+		appenderErrorCalls++
+		if appenderErrorCalls == 1 {
+			return "Invalid Input Error: flush failed"
+		}
+		return "Invalid Input Error: clear failed"
+	})
+	patchVar(t, &mapping.AppenderClear, func(_ mapping.Appender) mapping.State {
+		spies.clear = true
+		return mapping.StateError
+	})
+
+	a := newStubAppender()
+
+	err := a.CloseWithCancel(context.Background())
+	require.ErrorIs(t, err, errAppenderClose)
+	require.ErrorContains(t, err, "flush failed")
+	require.ErrorContains(t, err, "clear failed")
+	require.ErrorContains(t, err, "failed to clear appender's internal data")
+	require.True(t, spies.clear, "failed close should still try to clear buffered appender state")
+}
+
+func TestAppenderCloseWithCancelAppendFailureIncludesError(t *testing.T) {
+	spies := stubAppenderMapping(t, mapping.StateSuccess, "Invalid Input Error: append failed")
+
+	var appendCalled bool
+	patchVar(t, &mapping.AppendDataChunk, func(_ mapping.Appender, _ mapping.DataChunk) mapping.State {
+		appendCalled = true
+		return mapping.StateError
+	})
+
+	a := newStubAppender()
+	a.rowCount = 1
+	a.chunk.columns = make([]vector, 1)
+
+	err := a.CloseWithCancel(context.Background())
+	require.ErrorIs(t, err, errAppenderClose)
+	require.ErrorContains(t, err, "append failed")
+	require.True(t, appendCalled, "CloseWithCancel should append buffered rows before flushing")
+	require.Equal(t, 1, spies.destroyAppenderCalls, "append failure should still destroy the appender")
+	require.Equal(t, 1, spies.destroyChunkCalls, "append failure should still destroy the data chunk")
+}
+
+func TestAppenderCloseWithCancelDestroyFailureReturnsError(t *testing.T) {
+	spies := stubAppenderMapping(t, mapping.StateSuccess, "")
+	patchVar(t, &mapping.AppenderDestroy, func(_ *mapping.Appender) mapping.State {
+		spies.destroyAppenderCalls++
+		return mapping.StateError
+	})
+
+	a := newStubAppender()
+
+	err := a.CloseWithCancel(context.Background())
+	require.ErrorIs(t, err, errAppenderClose)
+	require.Equal(t, 1, spies.destroyAppenderCalls, "failed destroy should only run once")
+	require.Equal(t, 1, spies.destroyChunkCalls, "failed destroy should still follow data chunk cleanup")
+}
+
+func TestAppenderCloseWithCancelDoubleCloseDoesNotDestroyAgain(t *testing.T) {
+	spies := stubAppenderMapping(t, mapping.StateSuccess, "")
+
+	a := newStubAppender()
+
+	require.NoError(t, a.CloseWithCancel(context.Background()))
+
+	err := a.CloseWithCancel(context.Background())
+	require.ErrorIs(t, err, errAppenderDoubleClose)
+	require.Equal(t, 1, spies.destroyAppenderCalls, "double close should not destroy the appender again")
+	require.Equal(t, 1, spies.destroyChunkCalls, "double close should not destroy the data chunk again")
+}

--- a/context_test.go
+++ b/context_test.go
@@ -16,11 +16,9 @@ import (
 func TestRunWithCtxInterrupt_PreCanceled(t *testing.T) {
 	// Stub Interrupt to count invocations.
 	var count atomic.Int64
-	orig := mapping.Interrupt
-	mapping.Interrupt = func(_ mapping.Connection) {
+	patchVar(t, &mapping.Interrupt, func(_ mapping.Connection) {
 		count.Add(1)
-	}
-	t.Cleanup(func() { mapping.Interrupt = orig })
+	})
 
 	// Pre-cancel the context.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -42,9 +40,7 @@ func TestRunWithCtxInterrupt_PreCanceled(t *testing.T) {
 // Test that when there is no cancellation, the wrapper does not call Interrupt.
 func TestRunWithCtxInterrupt_NoCancel_NoInterrupt(t *testing.T) {
 	var count atomic.Int64
-	orig := mapping.Interrupt
-	mapping.Interrupt = func(_ mapping.Connection) { count.Add(1) }
-	t.Cleanup(func() { mapping.Interrupt = orig })
+	patchVar(t, &mapping.Interrupt, func(_ mapping.Connection) { count.Add(1) })
 
 	ctx := context.Background()
 	called := false
@@ -62,14 +58,10 @@ func TestRunWithCtxInterrupt_NoCancel_NoInterrupt(t *testing.T) {
 // Test that after cancellation, Interrupt is invoked repeatedly until fn returns.
 func TestRunWithCtxInterrupt_Cancel_RepeatsUntilDone(t *testing.T) {
 	// Use a shorter interval for testing.
-	origInterval := interruptInterval
-	interruptInterval = 100 * time.Millisecond
-	t.Cleanup(func() { interruptInterval = origInterval })
+	patchVar(t, &interruptInterval, 100*time.Millisecond)
 
 	var count atomic.Int64
-	orig := mapping.Interrupt
-	mapping.Interrupt = func(_ mapping.Connection) { count.Add(1) }
-	t.Cleanup(func() { mapping.Interrupt = orig })
+	patchVar(t, &mapping.Interrupt, func(_ mapping.Connection) { count.Add(1) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -124,17 +116,13 @@ func TestRunWithCtxInterrupt_Cancel_RepeatsUntilDone(t *testing.T) {
 // Test that recursively wrapping with the same context only spawns a single interrupter goroutine.
 func TestRunWithCtxInterrupt_RecursiveOnlyOneGoroutine(t *testing.T) {
 	// Set a high interval to ensure only one call per goroutine until deadline set below
-	origInterval := interruptInterval
-	interruptInterval = 1 * time.Second
-	t.Cleanup(func() { interruptInterval = origInterval })
+	patchVar(t, &interruptInterval, 1*time.Second)
 
 	// Stub Interrupt to count calls
 	var interruptCount atomic.Int32
-	orig := mapping.Interrupt
-	mapping.Interrupt = func(_ mapping.Connection) {
+	patchVar(t, &mapping.Interrupt, func(_ mapping.Connection) {
 		interruptCount.Add(1)
-	}
-	t.Cleanup(func() { mapping.Interrupt = orig })
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/duckdb.go
+++ b/duckdb.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -116,10 +117,18 @@ func (c *Connector) Connect(ctx context.Context) (driver.Conn, error) {
 	cleanupCtx := conn.setContext(ctx)
 	defer cleanupCtx()
 
-	if c.connInitFn != nil {
-		if err := c.connInitFn(conn); err != nil {
+	if c.connInitFn == nil {
+		return conn, nil
+	}
+	if err := c.connInitFn(conn); err != nil {
+		// Close the fresh connection so a failed initializer does not leak the
+		// native handle. Return err directly when cleanup succeeds so callers
+		// that compare the initializer error by identity keep working.
+		closeErr := conn.Close()
+		if closeErr == nil || errors.Is(closeErr, errClosedCon) {
 			return nil, err
 		}
+		return nil, errors.Join(err, closeErr)
 	}
 
 	return conn, nil

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"math/big"
@@ -17,6 +18,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/duckdb/duckdb-go/v2/mapping"
 )
 
 /* ---------- Open and Close Wrappers ---------- */
@@ -133,6 +136,16 @@ func closeAppenderWrapper[T require.TestingT](t T, a *Appender) {
 
 /* ---------- Test Helpers ---------- */
 
+// patchVar temporarily sets *p to v and restores the original on test cleanup.
+// Used to swap package-level mapping hooks in tests that must not run in parallel.
+func patchVar[T any](t *testing.T, p *T, v T) {
+	t.Helper()
+
+	orig := *p
+	*p = v
+	t.Cleanup(func() { *p = orig })
+}
+
 func createTable(t *testing.T, db *sql.DB, query string) {
 	res, err := db.Exec(query)
 	require.NoError(t, err)
@@ -219,6 +232,57 @@ func TestConnector_Close(t *testing.T) {
 	// Multiple close calls must not cause panics or errors.
 	closeConnectorWrapper(t, c)
 	closeConnectorWrapper(t, c)
+}
+
+// This test patches package-level mapping hooks and must not run in parallel.
+func TestConnectCleansUpOnInitError(t *testing.T) {
+	initErr := errors.New("init failed")
+	c := newConnectorWrapper(t, ``, func(driver.ExecerContext) error {
+		return initErr
+	})
+	defer closeConnectorWrapper(t, c)
+
+	disconnectCount := countDisconnects(t)
+
+	conn, err := c.Connect(context.Background())
+	require.Nil(t, conn)
+	require.Equal(t, initErr, err)
+	require.ErrorIs(t, err, initErr)
+	require.Equal(t, 1, *disconnectCount)
+}
+
+func TestConnectKeepsInitErrorWhenInitAlreadyClosed(t *testing.T) {
+	initErr := errors.New("init failed")
+	c := newConnectorWrapper(t, ``, func(execer driver.ExecerContext) error {
+		conn, ok := execer.(driver.Conn)
+		require.True(t, ok)
+		require.NoError(t, conn.Close())
+		return initErr
+	})
+	defer closeConnectorWrapper(t, c)
+
+	disconnectCount := countDisconnects(t)
+
+	conn, err := c.Connect(context.Background())
+	require.Nil(t, conn)
+	require.Equal(t, initErr, err)
+	require.ErrorIs(t, err, initErr)
+	require.Equal(t, 1, *disconnectCount)
+}
+
+func countDisconnects(t *testing.T) *int {
+	t.Helper()
+
+	// Connect is single-goroutine, so a plain counter is enough. The stub calls
+	// through to the real Disconnect so the fresh connection is actually torn down.
+	var disconnectCount int
+	origDisconnect := mapping.Disconnect
+	patchVar(t, &mapping.Disconnect, func(conn *mapping.Connection) {
+		disconnectCount++
+		origDisconnect(conn)
+	})
+
+	return &disconnectCount
 }
 
 func ExampleNewConnector() {

--- a/errors.go
+++ b/errors.go
@@ -13,7 +13,7 @@ func getError(errDriver, err error) error {
 	if err == nil {
 		return fmt.Errorf("%s: %w", driverErrMsg, errDriver)
 	}
-	return fmt.Errorf("%s: %w: %s", driverErrMsg, errDriver, err.Error())
+	return fmt.Errorf("%s: %w: %w", driverErrMsg, errDriver, err)
 }
 
 func castError(actual, expected string) error {

--- a/errors_test.go
+++ b/errors_test.go
@@ -24,6 +24,14 @@ func testError(t *testing.T, actual error, contains ...string) {
 	testErrorInternal(t, actual, contains)
 }
 
+func TestGetErrorWrapsCause(t *testing.T) {
+	cause := errors.New("wrapped cause")
+
+	err := getError(errAppenderFlush, cause)
+	require.ErrorIs(t, err, errAppenderFlush)
+	require.ErrorIs(t, err, cause)
+}
+
 func TestErrConnect(t *testing.T) {
 	t.Run(errParseDSN.Error(), func(t *testing.T) {
 		db, err := sql.Open(`duckdb`, `:mem ory:`)

--- a/statement.go
+++ b/statement.go
@@ -758,6 +758,9 @@ func (s *Stmt) execute(ctx context.Context, args []driver.NamedValue) (*mapping.
 	return s.executeBound(ctx)
 }
 
+// interruptRoutine sends at most one interrupt when ctx is canceled before
+// mainDoneCh closes. Query execution uses runWithCtxInterrupt when it needs to
+// reassert interrupts on a timer.
 func interruptRoutine(mainDoneCh, bgDoneCh *chan struct{}, ctx context.Context, conn *Conn) {
 	select {
 	// Await an interrupt on the context.


### PR DESCRIPTION
This PR fixes two cleanup bugs and tightens appender cancellation coverage.

- Close the fresh DuckDB connection if `connInitFn` fails, avoiding a leak.
- Avoid resetting a destroyed appender chunk after flush failure.
