### PR TITLE
Harden internal type handling with typeName helper

### DIFF
--- a/data_chunk.go
+++ b/data_chunk.go
@@ -50,7 +50,11 @@ func (chunk *DataChunk) GetValue(colIdx, rowIdx int) (any, error) {
 	}
 
 	column := &chunk.columns[colIdx]
-	return column.getFn(column, mapping.IdxT(rowIdx)), nil
+	value, err := column.getFn(column, mapping.IdxT(rowIdx))
+	if err != nil {
+		return nil, getError(errAPI, addIndexToError(err, colIdx))
+	}
+	return value, nil
 }
 
 // SetValue writes a single value to a column in a data chunk.

--- a/enum_bench_test.go
+++ b/enum_bench_test.go
@@ -113,7 +113,8 @@ func benchEnumVector(b *testing.B, rowCount int, useCGO bool) {
 				}
 			} else {
 				for rowIdx := range chunk.size {
-					benchmarkEnumSink = vec.getEnum(mapping.IdxT(rowIdx))
+					benchmarkEnumSink, e = vec.getEnum(mapping.IdxT(rowIdx))
+					require.NoError(b, e)
 				}
 			}
 			count += chunk.size

--- a/rows.go
+++ b/rows.go
@@ -77,7 +77,11 @@ func (r *rows) Next(dst []driver.Value) error {
 	// always valid here since we control the chunk lifecycle.
 	rowIdx := mapping.IdxT(r.rowCount)
 	for colIdx := range r.chunk.columns {
-		dst[colIdx] = r.chunk.columns[colIdx].getFn(&r.chunk.columns[colIdx], rowIdx)
+		value, err := r.chunk.columns[colIdx].getFn(&r.chunk.columns[colIdx], rowIdx)
+		if err != nil {
+			return getError(errAPI, addIndexToError(err, colIdx))
+		}
+		dst[colIdx] = value
 		if bit, ok := dst[colIdx].(Bit); ok {
 			dst[colIdx] = bit.String()
 		}

--- a/type.go
+++ b/type.go
@@ -1,6 +1,8 @@
 package duckdb
 
 import (
+	"fmt"
+
 	"github.com/duckdb/duckdb-go/v2/mapping"
 )
 
@@ -102,6 +104,13 @@ var typeToStringMap = map[Type]string{
 	TYPE_SQLNULL:      "SQLNULL",
 	TYPE_GEOMETRY:     "GEOMETRY",
 	TYPE_VARIANT:      "VARIANT",
+}
+
+func typeName(t Type) string {
+	if name, ok := typeToStringMap[t]; ok {
+		return name
+	}
+	return fmt.Sprintf("%s (%d)", unknownTypeErrMsg, t)
 }
 
 const aliasJSON = "JSON"

--- a/typed_value.go
+++ b/typed_value.go
@@ -41,7 +41,7 @@ func Typed(value any, typ Type) TypedValue {
 
 func coerceTypedValue(t Type, v any) (any, error) {
 	if !supportsTypedValue(t) {
-		return nil, unsupportedTypeError(typedValueTypeName(t))
+		return nil, unsupportedTypeError(typeName(t))
 	}
 
 	if t == TYPE_SQLNULL || isNil(v) {
@@ -91,7 +91,7 @@ func coerceTypedValue(t Type, v any) (any, error) {
 		TYPE_DATE, TYPE_TIME, TYPE_TIME_TZ, TYPE_INTERVAL:
 		return v, nil
 	}
-	return nil, fmt.Errorf("duckdb: internal error: missing typed value coercion for %s", typedValueTypeName(t))
+	return nil, fmt.Errorf("duckdb: internal error: missing typed value coercion for %s", typeName(t))
 }
 
 func supportsTypedValue(t Type) bool {
@@ -185,16 +185,9 @@ func coerceTypedFloat64(t Type, v any) (any, error) {
 }
 
 func typedValueCastError(t Type, v any) error {
-	return castErrorForValue(v, typedValueTypeName(t))
+	return castErrorForValue(v, typeName(t))
 }
 
 func typedValueConversionError(t Type, v any) error {
-	return fmt.Errorf("%s: cannot convert %v to %s", convertErrMsg, v, typedValueTypeName(t))
-}
-
-func typedValueTypeName(t Type) string {
-	if name, ok := typeToStringMap[t]; ok {
-		return name
-	}
-	return unknownTypeErrMsg
+	return fmt.Errorf("%s: cannot convert %v to %s", convertErrMsg, v, typeName(t))
 }

--- a/typed_value_test.go
+++ b/typed_value_test.go
@@ -278,7 +278,7 @@ func TestTypedValidation(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				var got any
 				err := db.QueryRow(`SELECT ?`, Typed(tc.value, tc.typ)).Scan(&got)
-				require.ErrorContains(t, err, "unsupported data type: "+typedValueTypeName(tc.typ))
+				require.ErrorContains(t, err, "unsupported data type: "+typeName(tc.typ))
 				require.ErrorContains(t, err, "index: 1")
 			})
 		}

--- a/vector.go
+++ b/vector.go
@@ -151,11 +151,11 @@ func (vec *vector) initChildVectors(v mapping.Vector, writable bool) {
 }
 
 func initBool(vec *vector) {
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
-		return getPrimitive[bool](vec, rowIdx)
+		return getPrimitive[bool](vec, rowIdx), nil
 	}
 	vec.setFn = func(vec *vector, rowIdx mapping.IdxT, val any) error {
 		if val == nil {
@@ -168,11 +168,11 @@ func initBool(vec *vector) {
 }
 
 func initNumeric[T numericType](vec *vector, t Type) {
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
-		return getPrimitive[T](vec, rowIdx)
+		return getPrimitive[T](vec, rowIdx), nil
 	}
 	vec.setFn = func(vec *vector, rowIdx mapping.IdxT, val any) error {
 		if val == nil {
@@ -185,11 +185,11 @@ func initNumeric[T numericType](vec *vector, t Type) {
 }
 
 func (vec *vector) initTS(t Type) {
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
-		return vec.getTS(t, rowIdx)
+		return vec.getTS(t, rowIdx), nil
 	}
 	vec.setFn = func(vec *vector, rowIdx mapping.IdxT, val any) error {
 		if val == nil || val == (*time.Time)(nil) {
@@ -202,11 +202,11 @@ func (vec *vector) initTS(t Type) {
 }
 
 func (vec *vector) initDate() {
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
-		return vec.getDate(rowIdx)
+		return vec.getDate(rowIdx), nil
 	}
 	vec.setFn = func(vec *vector, rowIdx mapping.IdxT, val any) error {
 		if val == nil || val == (*time.Time)(nil) {
@@ -219,11 +219,11 @@ func (vec *vector) initDate() {
 }
 
 func (vec *vector) initTime(t Type) {
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
-		return vec.getTime(rowIdx)
+		return vec.getTime(rowIdx), nil
 	}
 	vec.setFn = func(vec *vector, rowIdx mapping.IdxT, val any) error {
 		if val == nil || val == (*time.Time)(nil) {
@@ -236,11 +236,11 @@ func (vec *vector) initTime(t Type) {
 }
 
 func (vec *vector) initInterval() {
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
-		return vec.getInterval(rowIdx)
+		return vec.getInterval(rowIdx), nil
 	}
 	vec.setFn = func(vec *vector, rowIdx mapping.IdxT, val any) error {
 		if val == nil || val == (*Interval)(nil) {
@@ -253,11 +253,11 @@ func (vec *vector) initInterval() {
 }
 
 func (vec *vector) initHugeint() {
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
-		return vec.getHugeint(rowIdx)
+		return vec.getHugeint(rowIdx), nil
 	}
 	vec.setFn = func(vec *vector, rowIdx mapping.IdxT, val any) error {
 		if val == nil || val == (*big.Int)(nil) {
@@ -270,11 +270,11 @@ func (vec *vector) initHugeint() {
 }
 
 func (vec *vector) initUhugeint() {
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
-		return vec.getUhugeint(rowIdx)
+		return vec.getUhugeint(rowIdx), nil
 	}
 	vec.setFn = func(vec *vector, rowIdx mapping.IdxT, val any) error {
 		if val == nil || val == (*big.Int)(nil) {
@@ -287,11 +287,11 @@ func (vec *vector) initUhugeint() {
 }
 
 func (vec *vector) initBignum() {
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
-		return vec.getBigNum(rowIdx)
+		return vec.getBigNum(rowIdx), nil
 	}
 	vec.setFn = func(vec *vector, rowIdx mapping.IdxT, val any) error {
 		if val == nil || val == (*big.Int)(nil) {
@@ -304,11 +304,11 @@ func (vec *vector) initBignum() {
 }
 
 func (vec *vector) initBytes(t Type) {
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
-		return vec.getBytes(rowIdx)
+		return vec.getBytes(rowIdx), nil
 	}
 	vec.setFn = func(vec *vector, rowIdx mapping.IdxT, val any) error {
 		if val == nil {
@@ -321,11 +321,11 @@ func (vec *vector) initBytes(t Type) {
 }
 
 func (vec *vector) initBit() {
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
-		return vec.getBit(rowIdx)
+		return vec.getBit(rowIdx), nil
 	}
 	vec.setFn = func(vec *vector, rowIdx mapping.IdxT, val any) error {
 		if val == nil || val == (*Bit)(nil) {
@@ -338,11 +338,11 @@ func (vec *vector) initBit() {
 }
 
 func (vec *vector) initJSON() {
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
-		return vec.getJSON(rowIdx)
+		return vec.getJSON(rowIdx), nil
 	}
 	vec.setFn = func(vec *vector, rowIdx mapping.IdxT, val any) error {
 		if val == nil {
@@ -361,9 +361,9 @@ func (vec *vector) initDecimal(logicalType mapping.LogicalType, colIdx int) erro
 	t := mapping.DecimalInternalType(logicalType)
 	switch t {
 	case TYPE_SMALLINT, TYPE_INTEGER, TYPE_BIGINT, TYPE_HUGEINT:
-		vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+		vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 			if vec.getNull(rowIdx) {
-				return nil
+				return nil, nil
 			}
 			return vec.getDecimal(rowIdx)
 		}
@@ -400,9 +400,9 @@ func (vec *vector) initEnum(logicalType mapping.LogicalType, colIdx int) error {
 	t := mapping.EnumInternalType(logicalType)
 	switch t {
 	case TYPE_UTINYINT, TYPE_USMALLINT, TYPE_UINTEGER, TYPE_UBIGINT:
-		vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+		vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 			if vec.getNull(rowIdx) {
-				return nil
+				return nil, nil
 			}
 			return vec.getEnum(rowIdx)
 		}
@@ -434,9 +434,9 @@ func (vec *vector) initList(logicalType mapping.LogicalType, colIdx int) error {
 		return err
 	}
 
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
 		return vec.getList(rowIdx)
 	}
@@ -485,9 +485,9 @@ func (vec *vector) initStruct(logicalType mapping.LogicalType, colIdx int) error
 	}
 	vec.structTemplate = tmpl
 
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
 		return vec.getStruct(rowIdx)
 	}
@@ -527,9 +527,9 @@ func (vec *vector) initMap(logicalType mapping.LogicalType, colIdx int) error {
 		return addIndexToError(errUnsupportedMapKeyType, colIdx)
 	}
 
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
 		return vec.getMap(rowIdx)
 	}
@@ -558,9 +558,9 @@ func (vec *vector) initArray(logicalType mapping.LogicalType, colIdx int) error 
 		return err
 	}
 
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
 		return vec.getArray(rowIdx)
 	}
@@ -604,9 +604,9 @@ func (vec *vector) initUnion(logicalType mapping.LogicalType, colIdx int) error 
 		vec.tagDict[uint32(i)] = name
 	}
 
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
 		return vec.getUnion(rowIdx)
 	}
@@ -622,12 +622,12 @@ func (vec *vector) initUnion(logicalType mapping.LogicalType, colIdx int) error 
 }
 
 func (vec *vector) initUUID() {
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
 		if vec.getNull(rowIdx) {
-			return nil
+			return nil, nil
 		}
 		hugeInt := getPrimitive[mapping.HugeInt](vec, rowIdx)
-		return hugeIntToUUID(&hugeInt)
+		return hugeIntToUUID(&hugeInt), nil
 	}
 	vec.setFn = func(vec *vector, rowIdx mapping.IdxT, val any) error {
 		if val == nil || val == (*UUID)(nil) {
@@ -640,8 +640,8 @@ func (vec *vector) initUUID() {
 }
 
 func (vec *vector) initSQLNull() {
-	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) any {
-		return nil
+	vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
+		return nil, nil
 	}
 	vec.setFn = func(vec *vector, rowIdx mapping.IdxT, val any) error {
 		return errSetSQLNULLValue

--- a/vector_getters.go
+++ b/vector_getters.go
@@ -12,7 +12,7 @@ import (
 )
 
 // fnGetVectorValue is the getter callback function for any (nested) vector.
-type fnGetVectorValue func(vec *vector, rowIdx mapping.IdxT) any
+type fnGetVectorValue func(vec *vector, rowIdx mapping.IdxT) (any, error)
 
 // getNull checks DuckDB's validity bitfield: one bit per row packed into uint64 entries.
 // Bit = 1 means valid (not null), bit = 0 means null.
@@ -213,7 +213,7 @@ func (vec *vector) getJSON(rowIdx mapping.IdxT) any {
 	return value
 }
 
-func (vec *vector) getDecimal(rowIdx mapping.IdxT) Decimal {
+func (vec *vector) getDecimal(rowIdx mapping.IdxT) (Decimal, error) {
 	var val *big.Int
 	switch vec.internalType {
 	case TYPE_SMALLINT:
@@ -229,12 +229,12 @@ func (vec *vector) getDecimal(rowIdx mapping.IdxT) Decimal {
 		v := getPrimitive[mapping.HugeInt](vec, rowIdx)
 		val = hugeIntToNative(&v)
 	default:
-		panic(unsupportedTypeError(typeName(vec.internalType)))
+		return Decimal{}, unsupportedTypeError(typeName(vec.internalType))
 	}
-	return Decimal{Width: vec.decimalWidth, Scale: vec.decimalScale, Value: val}
+	return Decimal{Width: vec.decimalWidth, Scale: vec.decimalScale, Value: val}, nil
 }
 
-func (vec *vector) getEnum(rowIdx mapping.IdxT) string {
+func (vec *vector) getEnum(rowIdx mapping.IdxT) (string, error) {
 	var idx mapping.IdxT
 	switch vec.internalType {
 	case TYPE_UTINYINT:
@@ -246,32 +246,39 @@ func (vec *vector) getEnum(rowIdx mapping.IdxT) string {
 	case TYPE_UBIGINT:
 		idx = mapping.IdxT(getPrimitive[uint64](vec, rowIdx))
 	default:
-		panic(unsupportedTypeError(typeName(vec.internalType)))
+		return "", unsupportedTypeError(typeName(vec.internalType))
 	}
 
 	// Use the pre-built slice instead of CGO round-trips.
 	// Before: VectorGetColumnType + EnumDictionaryValue + DestroyLogicalType per cell.
 	// After:  single slice index — no CGO, no hashing, no heap allocation.
-	return vec.enumDict[idx]
+	return vec.enumDict[idx], nil
 }
 
-func (vec *vector) getList(rowIdx mapping.IdxT) []any {
+func (vec *vector) getList(rowIdx mapping.IdxT) ([]any, error) {
 	entry := getPrimitive[mapping.ListEntry](vec, rowIdx)
 	offset, length := mapping.ListEntryMembers(&entry)
 	return vec.getSliceChild(offset, length)
 }
 
-func (vec *vector) getStruct(rowIdx mapping.IdxT) map[string]any {
+func (vec *vector) getStruct(rowIdx mapping.IdxT) (map[string]any, error) {
 	m := maps.Clone(vec.structTemplate)
 	for i := range vec.childVectors {
 		child := &vec.childVectors[i]
-		m[vec.structEntries[i].Name()] = child.getFn(child, rowIdx)
+		val, err := child.getFn(child, rowIdx)
+		if err != nil {
+			return nil, err
+		}
+		m[vec.structEntries[i].Name()] = val
 	}
-	return m
+	return m, nil
 }
 
-func (vec *vector) getMap(rowIdx mapping.IdxT) OrderedMap {
-	list := vec.getList(rowIdx)
+func (vec *vector) getMap(rowIdx mapping.IdxT) (OrderedMap, error) {
+	list, err := vec.getList(rowIdx)
+	if err != nil {
+		return OrderedMap{}, err
+	}
 
 	m := OrderedMap{}
 	for i := range list {
@@ -280,33 +287,39 @@ func (vec *vector) getMap(rowIdx mapping.IdxT) OrderedMap {
 		val := mapItem[mapValuesField()]
 		m.Set(key, val)
 	}
-	return m
+	return m, nil
 }
 
-func (vec *vector) getArray(rowIdx mapping.IdxT) []any {
+func (vec *vector) getArray(rowIdx mapping.IdxT) ([]any, error) {
 	length := uint64(vec.arrayLength)
 	return vec.getSliceChild(uint64(rowIdx)*length, length)
 }
 
-func (vec *vector) getSliceChild(offset, length uint64) []any {
+func (vec *vector) getSliceChild(offset, length uint64) ([]any, error) {
 	slice := make([]any, 0, length)
 	child := &vec.childVectors[0]
 
 	// Fill the slice with all child values.
 	for i := range length {
-		val := child.getFn(child, mapping.IdxT(i+offset))
+		val, err := child.getFn(child, mapping.IdxT(i+offset))
+		if err != nil {
+			return nil, err
+		}
 		slice = append(slice, val)
 	}
-	return slice
+	return slice, nil
 }
 
-func (vec *vector) getUnion(rowIdx mapping.IdxT) any {
+func (vec *vector) getUnion(rowIdx mapping.IdxT) (any, error) {
 	tag := getPrimitive[uint8](&vec.childVectors[0], rowIdx)
 	child := &vec.childVectors[tag+1]
-	value := child.getFn(child, rowIdx)
+	value, err := child.getFn(child, rowIdx)
+	if err != nil {
+		return nil, err
+	}
 
 	return Union{
 		Tag:   vec.tagDict[uint32(tag)],
 		Value: value,
-	}
+	}, nil
 }

--- a/vector_getters.go
+++ b/vector_getters.go
@@ -228,6 +228,8 @@ func (vec *vector) getDecimal(rowIdx mapping.IdxT) Decimal {
 	case TYPE_HUGEINT:
 		v := getPrimitive[mapping.HugeInt](vec, rowIdx)
 		val = hugeIntToNative(&v)
+	default:
+		panic(unsupportedTypeError(typeName(vec.internalType)))
 	}
 	return Decimal{Width: vec.decimalWidth, Scale: vec.decimalScale, Value: val}
 }
@@ -243,6 +245,8 @@ func (vec *vector) getEnum(rowIdx mapping.IdxT) string {
 		idx = mapping.IdxT(getPrimitive[uint32](vec, rowIdx))
 	case TYPE_UBIGINT:
 		idx = mapping.IdxT(getPrimitive[uint64](vec, rowIdx))
+	default:
+		panic(unsupportedTypeError(typeName(vec.internalType)))
 	}
 
 	// Use the pre-built slice instead of CGO round-trips.

--- a/vector_setters.go
+++ b/vector_setters.go
@@ -276,8 +276,9 @@ func setDecimal[S any](vec *vector, rowIdx mapping.IdxT, val S) error {
 		return setNumeric[S, int64](vec, rowIdx, val)
 	case TYPE_HUGEINT:
 		return setHugeint(vec, rowIdx, val)
+	default:
+		return unsupportedTypeError(typeName(vec.internalType))
 	}
-	return nil
 }
 
 func setEnum[S any](vec *vector, rowIdx mapping.IdxT, val S) error {

--- a/vector_test.go
+++ b/vector_test.go
@@ -1,6 +1,7 @@
 package duckdb
 
 import (
+	"database/sql/driver"
 	"testing"
 	"unsafe"
 
@@ -80,4 +81,71 @@ func TestSetGetPrimitiveLargeIndex(t *testing.T) {
 		got := getPrimitive[int32](vec, tc.idx)
 		require.Equal(t, tc.val, got, "value at index %d", tc.idx)
 	}
+}
+
+func TestDataChunkGetValueBubblesGetterErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*vector)
+	}{
+		{
+			name: "decimal",
+			setup: func(vec *vector) {
+				vec.Type = TYPE_DECIMAL
+				vec.internalType = TYPE_VARCHAR
+				vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
+					return vec.getDecimal(rowIdx)
+				}
+			},
+		},
+		{
+			name: "enum",
+			setup: func(vec *vector) {
+				vec.Type = TYPE_ENUM
+				vec.internalType = TYPE_VARCHAR
+				vec.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
+					return vec.getEnum(rowIdx)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var column vector
+			tc.setup(&column)
+			chunk := DataChunk{columns: []vector{column}}
+
+			var err error
+			require.NotPanics(t, func() {
+				_, err = chunk.GetValue(0, 0)
+			})
+			require.ErrorIs(t, err, errAPI)
+			require.ErrorContains(t, err, unsupportedTypeErrMsg)
+		})
+	}
+}
+
+func TestRowsNextBubblesGetterErrors(t *testing.T) {
+	var column vector
+	column.Type = TYPE_DECIMAL
+	column.internalType = TYPE_VARCHAR
+	column.getFn = func(vec *vector, rowIdx mapping.IdxT) (any, error) {
+		return vec.getDecimal(rowIdx)
+	}
+
+	r := rows{
+		chunk: DataChunk{
+			columns: []vector{column},
+			size:    1,
+		},
+	}
+	dst := make([]driver.Value, 1)
+
+	var err error
+	require.NotPanics(t, func() {
+		err = r.Next(dst)
+	})
+	require.ErrorIs(t, err, errAPI)
+	require.ErrorContains(t, err, unsupportedTypeErrMsg)
 }


### PR DESCRIPTION
Add a `typeName` helper with an unknown-type fallback and use it in new defensive default branches:

- `getDecimal` and `getEnum` panic on an unsupported internal type
- `setDecimal` returns an error instead of nil
