### PR TITLE
Surface invalid JSON read errors

### DIFF
--- a/vector.go
+++ b/vector.go
@@ -346,7 +346,7 @@ func (vec *vector) initJSON() {
 		if vec.getNull(rowIdx) {
 			return nil, nil
 		}
-		return vec.getJSON(rowIdx), nil
+		return vec.getJSON(rowIdx)
 	}
 	vec.setFn = func(vec *vector, rowIdx mapping.IdxT, val any) error {
 		if val == nil {

--- a/vector_getters.go
+++ b/vector_getters.go
@@ -206,11 +206,13 @@ func (vec *vector) getBit(rowIdx mapping.IdxT) Bit {
 	return Bit{Data: []byte(str)}
 }
 
-func (vec *vector) getJSON(rowIdx mapping.IdxT) any {
+func (vec *vector) getJSON(rowIdx mapping.IdxT) (any, error) {
 	bytes := vec.getBytes(rowIdx).(string)
 	var value any
-	_ = json.Unmarshal([]byte(bytes), &value)
-	return value
+	if err := json.Unmarshal([]byte(bytes), &value); err != nil {
+		return nil, err
+	}
+	return value, nil
 }
 
 func (vec *vector) getDecimal(rowIdx mapping.IdxT) (Decimal, error) {

--- a/vector_getters.go
+++ b/vector_getters.go
@@ -207,9 +207,12 @@ func (vec *vector) getBit(rowIdx mapping.IdxT) Bit {
 }
 
 func (vec *vector) getJSON(rowIdx mapping.IdxT) (any, error) {
-	bytes := vec.getBytes(rowIdx).(string)
+	data, ok := vec.getBytes(rowIdx).(string)
+	if !ok {
+		return nil, errInternal
+	}
 	var value any
-	if err := json.Unmarshal([]byte(bytes), &value); err != nil {
+	if err := json.Unmarshal([]byte(data), &value); err != nil {
 		return nil, err
 	}
 	return value, nil

--- a/vector_test.go
+++ b/vector_test.go
@@ -2,6 +2,7 @@ package duckdb
 
 import (
 	"database/sql/driver"
+	"encoding/json"
 	"testing"
 	"unsafe"
 
@@ -124,6 +125,23 @@ func TestDataChunkGetValueBubblesGetterErrors(t *testing.T) {
 			require.ErrorContains(t, err, unsupportedTypeErrMsg)
 		})
 	}
+}
+
+func TestDataChunkGetValueReturnsJSONDecodeError(t *testing.T) {
+	logicalType := mapping.CreateLogicalType(TYPE_VARCHAR)
+	mapping.LogicalTypeSetAlias(logicalType, aliasJSON)
+	defer mapping.DestroyLogicalType(&logicalType)
+
+	var chunk DataChunk
+	require.NoError(t, chunk.initFromTypes([]mapping.LogicalType{logicalType}, true))
+	defer chunk.close()
+
+	require.NoError(t, setBytes(&chunk.columns[0], 0, "invalid"))
+	got, err := chunk.GetValue(0, 0)
+	require.Nil(t, got)
+	require.ErrorIs(t, err, errAPI)
+	var syntaxErr *json.SyntaxError
+	require.ErrorAs(t, err, &syntaxErr)
 }
 
 func TestRowsNextBubblesGetterErrors(t *testing.T) {


### PR DESCRIPTION
Surface JSON decoding failures from vector reads instead of returning nil, so malformed JSON remains distinguishable from SQL NULL.

- Propagate `json.Unmarshal` errors through `DataChunk.GetValue`.
- Return `errInternal` instead of panicking if JSON storage stops yielding `VARCHAR` data.