### PR TITLE
feat: native chunk query API for allocation-free result reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,53 @@ defer appender.Close()
 err = appender.AppendRow(...)
 ```
 
+## DuckDB Data Chunk API
+
+`QueryChunksContext` executes a query and passes DuckDB's native data chunks to a
+callback, one at a time. It exists for results that are forwarded rather than
+scanned into Go values, e.g., serialized to NDJSON and written to a socket. On
+such path, `database/sql` copies and boxes every value only for it to be
+discarded. Reading the chunks directly avoids that. `GetVarcharView` and
+`GetBlobView` return the bytes where DuckDB already holds them, instead of copying
+them out. They report whether the value is non-NULL, which distinguishes SQL NULL
+from the empty string.
+
+```go
+db, err := sql.Open("duckdb", "")
+defer db.Close()
+
+conn, err := db.Conn(context.Background())
+defer conn.Close()
+
+buf := make([]byte, 0, 64*1024)
+err = duckdb.QueryChunksContext(context.Background(), conn,
+	`SELECT to_json(t)::VARCHAR FROM my_table AS t`,
+	func(chunk *duckdb.DataChunk) error {
+		for row := range chunk.GetSize() {
+			value, notNull, err := chunk.GetVarcharView(0, row)
+			if err != nil {
+				return err
+			}
+			if notNull {
+				buf = append(buf, value...)
+				buf = append(buf, '\n')
+			}
+		}
+		return nil
+	})
+```
+
+The views alias DuckDB's memory and stay valid only until the chunk is released,
+which is when the callback returns. Copy what you need to keep, and neither
+retain the `*DataChunk` nor modify a view. This is the contract of
+`driver.Rows.Next`, whose `[]byte` values are likewise only valid until the next
+call. Returning an error from the callback stops the iteration and returns that
+error unchanged, so a sentinel error can stop it early.
+
+The connection is occupied for the whole call, so the callback must not issue
+queries on it. DuckDB materializes the result before the first chunk is fetched,
+so this bounds what the caller allocates, not what DuckDB does.
+
 ## DuckDB Profiling API
 
 This section describes using the [DuckDB Profiling API](https://duckdb.org/docs/dev/profiling.html).

--- a/chunk_query.go
+++ b/chunk_query.go
@@ -1,0 +1,172 @@
+package duckdb
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+
+	"github.com/duckdb/duckdb-go/v2/mapping"
+)
+
+// QueryChunksContext executes a query and passes each native result chunk to
+// consume. It exists to read results without the per-row allocations of
+// database/sql: values can be read straight out of DuckDB's vectors, e.g., via
+// DataChunk.GetVarcharView.
+//
+// The chunks arrive in result order, and consume observes one chunk at a time.
+// Returning an error from consume stops the iteration and returns that error
+// unchanged, so a sentinel error stops the iteration early.
+// consume is not called at all for a result without rows.
+//
+// The connection is occupied for the whole call. consume must therefore not
+// issue queries on sqlConn, which would deadlock. Note that DuckDB materializes
+// the result before the first chunk is fetched, so this API bounds the memory
+// that the caller allocates, not the memory that DuckDB does.
+//
+// The same *DataChunk is reused for every chunk, and its C-allocated memory is
+// released once consume returns. Neither the chunk nor anything aliasing it may
+// be retained beyond that. args accept the same types as db.QueryContext, as
+// they go through the same conversion. If query holds multiple statements, all
+// but the last are executed, and only the last one yields chunks.
+func QueryChunksContext(
+	ctx context.Context,
+	sqlConn *sql.Conn,
+	query string,
+	consume func(*DataChunk) error,
+	args ...any,
+) error {
+	if sqlConn == nil {
+		return getError(errAPI, errNilConn)
+	}
+	if consume == nil {
+		return getError(errAPI, errNilChunkConsumer)
+	}
+
+	return sqlConn.Raw(func(driverConn any) error {
+		conn, ok := driverConn.(*Conn)
+		if !ok {
+			return getError(errAPI, invalidConnError(driverConn))
+		}
+		namedArgs, err := conn.convertChunkArgs(args)
+		if err != nil {
+			return err
+		}
+		return conn.queryChunksContext(ctx, query, namedArgs, consume)
+	})
+}
+
+// convertChunkArgs applies the argument conversion that database/sql would have
+// applied on its way to the driver: CheckNamedValue first, and the default
+// converter for the values it skips. Binding args verbatim instead would accept
+// a narrower set of types here than the same query accepts through
+// db.QueryContext.
+func (conn *Conn) convertChunkArgs(args []any) ([]driver.NamedValue, error) {
+	namedArgs := make([]driver.NamedValue, len(args))
+	for i, arg := range args {
+		nv := driver.NamedValue{Ordinal: i + 1, Value: arg}
+		if named, ok := arg.(sql.NamedArg); ok {
+			nv.Name, nv.Value = named.Name, named.Value
+		}
+
+		err := conn.CheckNamedValue(&nv)
+		if errors.Is(err, driver.ErrSkip) {
+			nv.Value, err = driver.DefaultParameterConverter.ConvertValue(nv.Value)
+		}
+		if err != nil {
+			return nil, getError(errAPI, addIndexToError(err, i+1))
+		}
+		namedArgs[i] = nv
+	}
+	return namedArgs, nil
+}
+
+// queryChunksContext prepares query on conn, streams its chunks to consume, and
+// closes the statement before returning.
+func (conn *Conn) queryChunksContext(
+	ctx context.Context,
+	query string,
+	args []driver.NamedValue,
+	consume func(*DataChunk) error,
+) error {
+	if conn.closed {
+		return errClosedCon
+	}
+
+	cleanupCtx := conn.setContext(ctx)
+	defer cleanupCtx()
+
+	return runWithCtxInterrupt(ctx, conn.conn, func(wctx context.Context) (err error) {
+		prepared, err := conn.prepareStmts(wctx, query)
+		if err != nil {
+			return err
+		}
+
+		defer func() {
+			closeErr := prepared.Close()
+			switch {
+			case err != nil && closeErr != nil:
+				err = errors.Join(err, closeErr)
+			case closeErr != nil:
+				err = closeErr
+			}
+		}()
+
+		return consumePreparedChunks(wctx, prepared, args, consume)
+	})
+}
+
+// consumePreparedChunks executes prepared and passes every result chunk to
+// consume, one at a time. It owns all C-allocated memory involved: the result is
+// destroyed on return, and each fetched chunk is freed after consume observes it.
+func consumePreparedChunks(
+	ctx context.Context,
+	prepared *Stmt,
+	args []driver.NamedValue,
+	consume func(*DataChunk) error,
+) error {
+	result, err := prepared.execute(ctx, args)
+	if err != nil {
+		return err
+	}
+	defer mapping.DestroyResult(result)
+
+	columnCount := mapping.ColumnCount(result)
+	columnNames := make([]string, columnCount)
+	for i := range columnNames {
+		columnNames[i] = mapping.ColumnName(result, mapping.IdxT(i))
+	}
+
+	var chunk DataChunk
+	chunk.columnNames = columnNames
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		nativeChunk := mapping.FetchChunk(*result)
+		if nativeChunk.Ptr == nil {
+			if errMsg := mapping.ResultError(result); errMsg != "" {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				return getDuckDBError(errMsg)
+			}
+			return ctx.Err()
+		}
+		if err := chunk.initFromDuckDataChunk(nativeChunk, false); err != nil {
+			mapping.DestroyDataChunk(&nativeChunk)
+			return getError(errAPI, err)
+		}
+
+		err := consumeResultChunk(&chunk, consume)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// consumeResultChunk passes chunk to consume and frees its C-allocated memory.
+func consumeResultChunk(chunk *DataChunk, consume func(*DataChunk) error) error {
+	defer chunk.close()
+	return consume(chunk)
+}

--- a/chunk_query_bench_test.go
+++ b/chunk_query_bench_test.go
@@ -1,0 +1,88 @@
+package duckdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const benchChunkRowCount = 100_000
+
+// benchChunkQuery serializes every row to a single VARCHAR column.
+var benchChunkQuery = fmt.Sprintf(
+	`SELECT to_json(r)::VARCHAR FROM (
+		SELECT i AS id, i::VARCHAR AS name, i * 1.5 AS value FROM range(%d) AS values(i)
+	) AS r`, benchChunkRowCount)
+
+func setupChunkBench(b *testing.B) (*sql.Conn, []byte) {
+	b.Helper()
+	db := openDbWrapper(b, "")
+	conn := openConnWrapper(b, db, context.Background())
+	b.Cleanup(func() {
+		closeConnWrapper(b, conn)
+		closeDbWrapper(b, db)
+	})
+	return conn, make([]byte, 0, 128*1024)
+}
+
+// BenchmarkQueryChunks reads the result through the native chunk API.
+func BenchmarkQueryChunks(b *testing.B) {
+	conn, buf := setupChunkBench(b)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		buf = buf[:0]
+		err := QueryChunksContext(context.Background(), conn, benchChunkQuery,
+			func(chunk *DataChunk) error {
+				for rowIdx := range chunk.GetSize() {
+					value, valid, err := chunk.GetVarcharView(0, rowIdx)
+					if err != nil {
+						return err
+					}
+					if !valid {
+						continue
+					}
+					if len(value)+1 > cap(buf)-len(buf) {
+						_, _ = io.Discard.Write(buf)
+						buf = buf[:0]
+					}
+					buf = append(buf, value...)
+					buf = append(buf, '\n')
+				}
+				return nil
+			},
+		)
+		require.NoError(b, err)
+	}
+}
+
+// BenchmarkQueryRows reads the result through database/sql.
+func BenchmarkQueryRows(b *testing.B) {
+	conn, buf := setupChunkBench(b)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		buf = buf[:0]
+		rows, err := conn.QueryContext(context.Background(), benchChunkQuery)
+		require.NoError(b, err)
+
+		var value string
+		for rows.Next() {
+			if err := rows.Scan(&value); err != nil {
+				b.Fatal(err)
+			}
+			if len(value)+1 > cap(buf)-len(buf) {
+				_, _ = io.Discard.Write(buf)
+				buf = buf[:0]
+			}
+			buf = append(buf, value...)
+			buf = append(buf, '\n')
+		}
+		require.NoError(b, rows.Err())
+		require.NoError(b, rows.Close())
+	}
+}

--- a/chunk_query_test.go
+++ b/chunk_query_test.go
@@ -1,0 +1,509 @@
+package duckdb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/duckdb/duckdb-go/v2/mapping"
+)
+
+func TestQueryChunksContext(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	var chunks, rows int
+	err := QueryChunksContext(t.Context(), conn,
+		"SELECT i::VARCHAR FROM range(?) AS values(i)",
+		func(chunk *DataChunk) error {
+			chunks++
+			for row := range chunk.GetSize() {
+				value, valid, err := chunk.GetVarcharView(0, row)
+				require.NoError(t, err)
+				require.True(t, valid)
+				require.Equal(t, strconv.Itoa(rows), string(value))
+				rows++
+			}
+			return nil
+		},
+		5000,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 5000, rows)
+	require.Greater(t, chunks, 1)
+}
+
+func TestQueryChunksContextViews(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	err := QueryChunksContext(t.Context(), conn,
+		`SELECT NULL::VARCHAR, ''::VARCHAR, repeat('x', 32),
+			NULL::BLOB, ''::BLOB, encode(repeat('x', 32)), 42::INTEGER`,
+		func(chunk *DataChunk) error {
+			value, valid, err := chunk.GetVarcharView(0, 0)
+			require.NoError(t, err)
+			require.False(t, valid)
+			require.Nil(t, value)
+
+			value, valid, err = chunk.GetVarcharView(1, 0)
+			require.NoError(t, err)
+			require.True(t, valid)
+			require.Empty(t, value)
+
+			value, valid, err = chunk.GetVarcharView(2, 0)
+			require.NoError(t, err)
+			require.True(t, valid)
+			require.Equal(t, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", string(value))
+
+			value, valid, err = chunk.GetBlobView(3, 0)
+			require.NoError(t, err)
+			require.False(t, valid)
+			require.Nil(t, value)
+
+			value, valid, err = chunk.GetBlobView(4, 0)
+			require.NoError(t, err)
+			require.True(t, valid)
+			require.Empty(t, value)
+
+			value, valid, err = chunk.GetBlobView(5, 0)
+			require.NoError(t, err)
+			require.True(t, valid)
+			require.Equal(t, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", string(value))
+
+			_, _, err = chunk.GetBlobView(0, 0)
+			require.Error(t, err)
+			_, _, err = chunk.GetVarcharView(6, 0)
+			require.Error(t, err)
+			_, _, err = chunk.GetVarcharView(0, 1)
+			require.Error(t, err)
+			_, _, err = chunk.GetVarcharView(99, 0)
+			require.ErrorContains(t, err, columnCountErrMsg)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+}
+
+func TestQueryChunksContextColumnNames(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	err := QueryChunksContext(t.Context(), conn,
+		"SELECT 1 AS id, 'x' AS label",
+		func(chunk *DataChunk) error {
+			require.Equal(t, []string{"id", "label"}, chunk.ColumnNames())
+
+			name, err := chunk.ColumnName(0)
+			require.NoError(t, err)
+			require.Equal(t, "id", name)
+
+			name, err = chunk.ColumnName(1)
+			require.NoError(t, err)
+			require.Equal(t, "label", name)
+
+			_, err = chunk.ColumnName(2)
+			require.Error(t, err)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+}
+
+// TestQueryChunksContextInlineBoundary covers both sides of the VARCHAR inline
+// length, where getBytesView switches from inlined data to an out-of-line pointer.
+func TestQueryChunksContextInlineBoundary(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	for _, length := range []int{1, 11, 12, 13, 24} {
+		t.Run(strconv.Itoa(length), func(t *testing.T) {
+			expected := strings.Repeat("x", length)
+			err := QueryChunksContext(t.Context(), conn,
+				"SELECT repeat('x', ?)::VARCHAR, encode(repeat('x', ?))",
+				func(chunk *DataChunk) error {
+					value, valid, err := chunk.GetVarcharView(0, 0)
+					require.NoError(t, err)
+					require.True(t, valid)
+					require.Equal(t, expected, string(value))
+
+					value, valid, err = chunk.GetBlobView(1, 0)
+					require.NoError(t, err)
+					require.True(t, valid)
+					require.Equal(t, expected, string(value))
+					return nil
+				},
+				length, length,
+			)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestQueryChunksContextAfterClose verifies that a retained chunk fails cleanly.
+func TestQueryChunksContextAfterClose(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	var leaked *DataChunk
+	err := QueryChunksContext(t.Context(), conn, "SELECT 'value'::VARCHAR AS v",
+		func(chunk *DataChunk) error {
+			leaked = chunk
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, leaked)
+
+	_, _, err = leaked.GetVarcharView(0, 0)
+	require.ErrorIs(t, err, errClosedChunk)
+	_, _, err = leaked.GetBlobView(0, 0)
+	require.ErrorIs(t, err, errClosedChunk)
+	_, err = leaked.GetValue(0, 0)
+	require.ErrorIs(t, err, errClosedChunk)
+	_, err = leaked.ColumnName(0)
+	require.ErrorIs(t, err, errClosedChunk)
+	require.ErrorIs(t, leaked.SetValue(0, 0, "x"), errClosedChunk)
+	require.ErrorIs(t, SetChunkValue(*leaked, 0, 0, "x"), errClosedChunk)
+	require.ErrorIs(t, leaked.SetSize(1), errClosedChunk)
+	require.Zero(t, leaked.GetSize())
+	require.Zero(t, leaked.ColumnCount())
+	require.Nil(t, leaked.ColumnNames())
+}
+
+func TestQueryChunksContextCancel(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var chunks int
+	err := QueryChunksContext(ctx, conn, "SELECT i FROM range(100000) AS values(i)",
+		func(*DataChunk) error {
+			chunks++
+			cancel()
+			return nil
+		},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, chunks)
+
+	// The connection must remain usable after an interrupted query.
+	var value string
+	require.NoError(t, conn.QueryRowContext(context.Background(), "SELECT 'ready'").Scan(&value))
+	require.Equal(t, "ready", value)
+}
+
+func TestQueryChunksContextCanceledBeforeCall(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	called := false
+	err := QueryChunksContext(ctx, conn, "SELECT 1",
+		func(*DataChunk) error { called = true; return nil },
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, called)
+}
+
+// TestQueryChunksContextNoRows verifies that consume is not called for a result without rows.
+func TestQueryChunksContextNoRows(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	for _, query := range []string{
+		"SELECT 1 WHERE false",
+		"CREATE TABLE no_rows (i INTEGER)",
+	} {
+		called := false
+		err := QueryChunksContext(t.Context(), conn, query,
+			func(*DataChunk) error { called = true; return nil },
+		)
+		require.NoError(t, err)
+		require.False(t, called, query)
+	}
+}
+
+// TestQueryChunksContextMultipleStmts verifies that all but the last statement
+// run for their side effects, and that only the last one yields chunks.
+func TestQueryChunksContextMultipleStmts(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	var rows int
+	err := QueryChunksContext(t.Context(), conn,
+		"CREATE TABLE multi (i INTEGER); INSERT INTO multi VALUES (1), (2); SELECT i FROM multi",
+		func(chunk *DataChunk) error {
+			rows += chunk.GetSize()
+			require.Equal(t, []string{"i"}, chunk.ColumnNames())
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, rows)
+}
+
+func TestQueryChunksContextArgs(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	t.Run("positional", func(t *testing.T) {
+		err := QueryChunksContext(t.Context(), conn, "SELECT ?::INTEGER + ?::INTEGER",
+			func(chunk *DataChunk) error {
+				value, err := chunk.GetValue(0, 0)
+				require.NoError(t, err)
+				require.Equal(t, int32(3), value)
+				return nil
+			},
+			1, 2,
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("named", func(t *testing.T) {
+		err := QueryChunksContext(t.Context(), conn, "SELECT $lhs::INTEGER + $rhs::INTEGER",
+			func(chunk *DataChunk) error {
+				value, err := chunk.GetValue(0, 0)
+				require.NoError(t, err)
+				require.Equal(t, int32(3), value)
+				return nil
+			},
+			sql.Named("lhs", 1), sql.Named("rhs", 2),
+		)
+		require.NoError(t, err)
+	})
+}
+
+func TestQueryChunksContextQueryError(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	called := false
+	err := QueryChunksContext(t.Context(), conn, "SELECT * FROM does_not_exist",
+		func(*DataChunk) error { called = true; return nil },
+	)
+	require.Error(t, err)
+	require.False(t, called)
+
+	var value string
+	require.NoError(t, conn.QueryRowContext(context.Background(), "SELECT 'ready'").Scan(&value))
+	require.Equal(t, "ready", value)
+}
+
+func TestQueryChunksContextFetchError(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	patchVar(t, &mapping.FetchChunk, func(mapping.Result) mapping.DataChunk {
+		return mapping.DataChunk{}
+	})
+	patchVar(t, &mapping.ResultError, func(*mapping.Result) string {
+		return "Executor Error: fetch failed"
+	})
+
+	called := false
+	err := QueryChunksContext(t.Context(), conn, "SELECT 1",
+		func(*DataChunk) error { called = true; return nil },
+	)
+	require.NotErrorIs(t, err, errAPI)
+	require.ErrorContains(t, err, "fetch failed")
+	var duckErr *Error
+	require.ErrorAs(t, err, &duckErr)
+	require.Equal(t, ErrorTypeExecutor, duckErr.Type)
+	require.False(t, called)
+}
+
+func TestQueryChunksContextCanceledDuringFetch(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	patchVar(t, &mapping.FetchChunk, func(mapping.Result) mapping.DataChunk {
+		cancel()
+		return mapping.DataChunk{}
+	})
+	patchVar(t, &mapping.ResultError, func(*mapping.Result) string {
+		return "Interrupt Error: interrupted"
+	})
+
+	called := false
+	err := QueryChunksContext(ctx, conn, "SELECT 1",
+		func(*DataChunk) error { called = true; return nil },
+	)
+	require.Equal(t, context.Canceled, err)
+	require.False(t, called)
+}
+
+// TestQueryChunksContextConsumerPanic verifies that the panic propagates intact
+// and the connection is discarded.
+func TestQueryChunksContextConsumerPanic(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+
+	require.PanicsWithValue(t, "consumer", func() {
+		_ = QueryChunksContext(t.Context(), conn, "SELECT i FROM range(10000) AS values(i)",
+			func(*DataChunk) error { panic("consumer") },
+		)
+	})
+
+	// database/sql discards a connection whose Raw callback panicked.
+	require.Error(t, conn.Close())
+}
+
+func TestQueryChunksContextConsumerError(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	expected := errors.New("stop")
+	err := QueryChunksContext(t.Context(), conn, "SELECT 'value'",
+		func(*DataChunk) error { return expected },
+	)
+	// Returned unchanged, so that a sentinel error can stop the iteration early.
+	require.Equal(t, expected, err)
+
+	var value string
+	require.NoError(t, conn.QueryRowContext(context.Background(), "SELECT 'ready'").Scan(&value))
+	require.Equal(t, "ready", value)
+}
+
+func TestQueryChunksContextRejectsNilConsumer(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	require.Error(t, QueryChunksContext(t.Context(), conn, "SELECT 1", nil))
+}
+
+func TestQueryChunksContextRejectsNilConnection(t *testing.T) {
+	require.Error(t, QueryChunksContext(t.Context(), nil, "SELECT 1",
+		func(*DataChunk) error { return nil },
+	))
+}
+
+// TestQueryChunksContextArgConversion pins that args go through the same
+// conversion database/sql applies, so a query accepts the same types on both
+// paths. A named type like ID, for one, needs the default converter to reach
+// int64.
+func TestQueryChunksContextArgConversion(t *testing.T) {
+	type ID int64
+
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	tests := []struct {
+		name  string
+		query string
+		arg   any
+	}{
+		{"named type", "SELECT ?::BIGINT = 42", ID(42)},
+		{"nil", "SELECT ?::INTEGER IS NULL", nil},
+		{"time", "SELECT ?::TIMESTAMP = '1970-01-01'::TIMESTAMP", time.Unix(0, 0).UTC()},
+		{"named arg", "SELECT $v::INTEGER = 7", sql.Named("v", 7)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var viaRows bool
+			require.NoError(t, conn.QueryRowContext(t.Context(), tc.query, tc.arg).Scan(&viaRows))
+			require.True(t, viaRows)
+
+			var viaChunks bool
+			err := QueryChunksContext(t.Context(), conn, tc.query,
+				func(chunk *DataChunk) error {
+					value, err := chunk.GetValue(0, 0)
+					require.NoError(t, err)
+					viaChunks = value.(bool)
+					return nil
+				},
+				tc.arg,
+			)
+			require.NoError(t, err)
+			require.Equal(t, viaRows, viaChunks)
+		})
+	}
+}
+
+// TestQueryChunksContextRejectsInvalidArg covers the conversion failing
+func TestQueryChunksContextRejectsInvalidArg(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	called := false
+	err := QueryChunksContext(t.Context(), conn, "SELECT ?::INTEGER",
+		func(*DataChunk) error { called = true; return nil },
+		make(chan int),
+	)
+	require.ErrorIs(t, err, errAPI)
+	require.ErrorContains(t, err, "chan int")
+	require.False(t, called)
+
+	var value string
+	require.NoError(t, conn.QueryRowContext(context.Background(), "SELECT 'ready'").Scan(&value))
+	require.Equal(t, "ready", value)
+}
+
+// TestQueryChunksContextUnsupportedColumnType covers a chunk that cannot be
+// initialized: it must be destroyed before the error is returned, so that the
+// column type DuckDB does support keeps working on the same connection.
+func TestQueryChunksContextUnsupportedColumnType(t *testing.T) {
+	db := openDbWrapper(t, "")
+	defer closeDbWrapper(t, db)
+	conn := openConnWrapper(t, db, t.Context())
+	defer closeConnWrapper(t, conn)
+
+	called := false
+	err := QueryChunksContext(t.Context(), conn, "SELECT NULL::VARIANT",
+		func(*DataChunk) error { called = true; return nil },
+	)
+	require.ErrorIs(t, err, errAPI)
+	require.ErrorContains(t, err, unsupportedTypeErrMsg)
+	require.False(t, called)
+
+	var value string
+	require.NoError(t, conn.QueryRowContext(context.Background(), "SELECT 'ready'").Scan(&value))
+	require.Equal(t, "ready", value)
+}

--- a/context.go
+++ b/context.go
@@ -93,17 +93,21 @@ func runWithCtxInterrupt(ctx context.Context, conn mapping.Connection, fn func(c
 
 	go interrupterRoutine(ctx, conn, done, bgDoneCh)
 
+	// Join the interrupter on every exit path, including a panic out of fn.
+	// An interrupter that outlives this call interrupts whatever runs on conn
+	// next, and dereferences conn even after the connection has been closed.
+	defer func() {
+		close(done)
+
+		// Wait for interrupter goroutine to finish
+		// Sometimes the go-routine is not scheduled immediately.
+		// By the time it is scheduled, another query might be running on this connection.
+		// If we don't wait for the go-routine to finish, it can cancel that new query.
+		<-bgDoneCh
+	}()
+
 	// We pass `ctx` to keep that "enriched" context with the mark that we've already spawned a go-routine
-	err := fn(ctx)
-
-	close(done)
-
-	// Wait for interrupter goroutine to finish
-	// Sometimes the go-routine is not scheduled immediately.
-	// By the time it is scheduled, another query might be running on this connection.
-	// If we don't wait for the go-routine to finish, it can cancel that new query.
-	<-bgDoneCh
-	return err
+	return fn(ctx)
 }
 
 func interrupterRoutine(ctx context.Context, conn mapping.Connection, done <-chan struct{}, bgDoneCh chan<- struct{}) {

--- a/context_test.go
+++ b/context_test.go
@@ -163,3 +163,33 @@ func TestRunWithCtxInterrupt_RecursiveOnlyOneGoroutine(t *testing.T) {
 	close(allowReturn)
 	require.NoError(t, <-doneErrCh)
 }
+
+// Test that a panic out of fn still joins the interrupter goroutine. An
+// interrupter that outlives the call interrupts the next query on the
+// connection, or dereferences a connection that has since been closed.
+func TestRunWithCtxInterrupt_PanicJoinsInterrupter(t *testing.T) {
+	patchVar(t, &interruptInterval, time.Millisecond)
+
+	var count atomic.Int64
+	patchVar(t, &mapping.Interrupt, func(_ mapping.Connection) { count.Add(1) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var dummyConn mapping.Connection
+	require.PanicsWithValue(t, "fn", func() {
+		_ = runWithCtxInterrupt(ctx, dummyConn, func(_ context.Context) error {
+			cancel()
+			// Let the interrupter observe the cancellation and start looping.
+			for count.Load() == 0 {
+				time.Sleep(100 * time.Microsecond)
+			}
+			panic("fn")
+		})
+	})
+
+	// The interrupter has been joined, so the count must not grow any further.
+	settled := count.Load()
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, settled, count.Load(), "interrupter should not outlive a panicking fn")
+}

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -114,6 +114,47 @@ func (chunk *DataChunk) GetValue(colIdx, rowIdx int) (any, error) {
 	return value, nil
 }
 
+// GetVarcharView returns the raw bytes of a VARCHAR value without copying them.
+// The second return value reports whether the value is non-NULL.
+//
+// The returned slice aliases DuckDB's internal memory and stays valid only until
+// the data chunk is released, which for QueryChunksContext is when the consume
+// callback returns. Callers must neither retain nor modify it: copy the bytes to
+// keep them. This mirrors the contract of driver.Rows.Next, whose []byte values
+// are only valid until the next call.
+func (chunk *DataChunk) GetVarcharView(colIdx, rowIdx int) ([]byte, bool, error) {
+	return chunk.getBytesView(colIdx, rowIdx, TYPE_VARCHAR)
+}
+
+// GetBlobView returns the raw bytes of a BLOB value without copying them.
+// The second return value reports whether the value is non-NULL.
+// The same aliasing rules as for GetVarcharView apply to the returned slice.
+func (chunk *DataChunk) GetBlobView(colIdx, rowIdx int) ([]byte, bool, error) {
+	return chunk.getBytesView(colIdx, rowIdx, TYPE_BLOB)
+}
+
+func (chunk *DataChunk) getBytesView(colIdx, rowIdx int, expected Type) ([]byte, bool, error) {
+	if err := chunk.checkValid(); err != nil {
+		return nil, false, getError(errAPI, err)
+	}
+	colIdx, err := chunk.verifyAndRewriteColIdx(colIdx)
+	if err != nil {
+		return nil, false, getError(errAPI, err)
+	}
+	if rowIdx < 0 || rowIdx >= chunk.size {
+		return nil, false, getError(errAPI, rowIndexError(rowIdx, chunk.size))
+	}
+
+	column := &chunk.columns[colIdx]
+	if column.Type != expected {
+		return nil, false, getError(errAPI, unexpectedTypeError(column.Type, expected))
+	}
+	if column.getNull(mapping.IdxT(rowIdx)) {
+		return nil, false, nil
+	}
+	return column.getBytesView(mapping.IdxT(rowIdx)), true, nil
+}
+
 // SetValue writes a single value to a column in a data chunk.
 // Note that this requires casting the type for each invocation.
 // If the column is not projected, the value is ignored.

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -20,6 +20,22 @@ type DataChunk struct {
 	size int
 	// projection mapping of projected columns, when known (otherwise empty)
 	projection []int
+	// closed is true after close released the underlying C-allocated memory.
+	closed bool
+}
+
+// checkValid guards against reading or writing a data chunk whose C-allocated
+// memory has already been freed.
+//
+// NOTE: This only covers the chunks that this package owns and closes itself.
+// Chunks passed to scalar and table UDF callbacks are owned by DuckDB, which
+// frees them once the callback returns: retaining one past its callback stays
+// unsafe and undetectable here.
+func (chunk *DataChunk) checkValid() error {
+	if chunk.closed {
+		return errClosedChunk
+	}
+	return nil
 }
 
 // GetDataChunkCapacity returns the capacity of a data chunk.
@@ -29,6 +45,9 @@ func GetDataChunkCapacity() int {
 
 // GetSize returns the internal size of the data chunk.
 func (chunk *DataChunk) GetSize() int {
+	if chunk.closed {
+		return 0
+	}
 	chunk.size = int(mapping.DataChunkGetSize(chunk.chunk))
 	return chunk.size
 }
@@ -40,6 +59,9 @@ func (chunk *DataChunk) ColumnCount() int {
 
 // SetSize sets the internal size of the data chunk. Cannot exceed GetCapacity().
 func (chunk *DataChunk) SetSize(size int) error {
+	if err := chunk.checkValid(); err != nil {
+		return getError(errAPI, err)
+	}
 	if size > GetDataChunkCapacity() {
 		return getError(errAPI, errVectorSize)
 	}
@@ -49,6 +71,9 @@ func (chunk *DataChunk) SetSize(size int) error {
 
 // GetValue returns a single value of a column.
 func (chunk *DataChunk) GetValue(colIdx, rowIdx int) (any, error) {
+	if err := chunk.checkValid(); err != nil {
+		return nil, getError(errAPI, err)
+	}
 	colIdx, err := chunk.verifyAndRewriteColIdx(colIdx)
 	if err != nil {
 		return nil, getError(errAPI, err)
@@ -67,6 +92,9 @@ func (chunk *DataChunk) GetValue(colIdx, rowIdx int) (any, error) {
 // If the column is not projected, the value is ignored.
 // NOTE: Custom ENUM types must be passed as string.
 func (chunk *DataChunk) SetValue(colIdx, rowIdx int, val any) error {
+	if err := chunk.checkValid(); err != nil {
+		return getError(errAPI, err)
+	}
 	colIdx, err := chunk.verifyAndRewriteColIdx(colIdx)
 	if err != nil && errors.Is(err, errUnprojectedColumn) {
 		return nil
@@ -88,6 +116,9 @@ func (chunk *DataChunk) SetValue(colIdx, rowIdx int, val any) error {
 // If the column is not projected, the value is ignored.
 // NOTE: Custom ENUM types must be passed as string.
 func SetChunkValue[T any](chunk DataChunk, colIdx, rowIdx int, val T) error {
+	if err := chunk.checkValid(); err != nil {
+		return getError(errAPI, err)
+	}
 	colIdx, err := chunk.verifyAndRewriteColIdx(colIdx)
 	if err != nil && errors.Is(err, errUnprojectedColumn) {
 		return nil
@@ -141,6 +172,7 @@ func (chunk *DataChunk) initFromTypes(types []mapping.LogicalType, writable bool
 
 	chunk.chunk = mapping.CreateDataChunk(types)
 	chunk.initVectors(writable)
+	chunk.closed = false
 
 	return nil
 }
@@ -163,6 +195,7 @@ func (chunk *DataChunk) initFromDuckDataChunk(inputChunk mapping.DataChunk, writ
 	columnCount := mapping.DataChunkGetColumnCount(inputChunk)
 	chunk.columns = make([]vector, columnCount)
 	chunk.chunk = inputChunk
+	chunk.closed = false
 
 	var err error
 	for i := range len(chunk.columns) {
@@ -178,9 +211,12 @@ func (chunk *DataChunk) initFromDuckDataChunk(inputChunk mapping.DataChunk, writ
 		// Initialize the vector and its child vectors.
 		chunk.columns[i].initVectors(vec, writable)
 	}
+	if err != nil {
+		return err
+	}
 	chunk.GetSize()
 
-	return err
+	return nil
 }
 
 func (chunk *DataChunk) initFromDuckVector(vec mapping.Vector, writable bool) error {
@@ -197,10 +233,17 @@ func (chunk *DataChunk) initFromDuckVector(vec mapping.Vector, writable bool) er
 
 	// Initialize the vector and its child vectors.
 	chunk.columns[0].initVectors(vec, writable)
+	chunk.closed = false
 
 	return nil
 }
 
+// close releases the C-allocated memory of the data chunk.
 func (chunk *DataChunk) close() {
 	mapping.DestroyDataChunk(&chunk.chunk)
+	chunk.closed = true
+	chunk.columns = nil
+	// NOTE: size stays as it was. rows.Next infers the end of a result from
+	// rowCount == size, so zeroing it here makes Next skip its fetch loop and
+	// return nil instead of io.EOF once the result is exhausted.
 }

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -57,6 +57,33 @@ func (chunk *DataChunk) ColumnCount() int {
 	return len(chunk.columns)
 }
 
+// ColumnNames returns the column names of the data chunk, indexed positionally.
+// It returns nil when column names are not available, and once the data chunk
+// has been closed. The returned slice belongs to the data chunk, and every chunk
+// of a result shares it: modifying it changes what ColumnName reports.
+func (chunk *DataChunk) ColumnNames() []string {
+	if chunk.closed {
+		return nil
+	}
+	return chunk.columnNames
+}
+
+// ColumnName returns the name of the column at colIdx (0-based). It returns an
+// error if colIdx is out of range, or if column names are not available.
+func (chunk *DataChunk) ColumnName(colIdx int) (string, error) {
+	if err := chunk.checkValid(); err != nil {
+		return "", getError(errAPI, err)
+	}
+	colIdx, err := chunk.verifyAndRewriteColIdx(colIdx)
+	if err != nil {
+		return "", getError(errAPI, err)
+	}
+	if colIdx < 0 || colIdx >= len(chunk.columnNames) {
+		return "", getError(errAPI, errUnknownColumnNames)
+	}
+	return chunk.columnNames[colIdx], nil
+}
+
 // SetSize sets the internal size of the data chunk. Cannot exceed GetCapacity().
 func (chunk *DataChunk) SetSize(size int) error {
 	if err := chunk.checkValid(); err != nil {

--- a/data_chunk_test.go
+++ b/data_chunk_test.go
@@ -1,0 +1,20 @@
+package duckdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDataChunkColumnNameUnknown covers the chunks that carry columns but no names.
+func TestDataChunkColumnNameUnknown(t *testing.T) {
+	chunk := DataChunk{columns: make([]vector, 2)}
+
+	require.Nil(t, chunk.ColumnNames())
+	_, err := chunk.ColumnName(0)
+	require.ErrorIs(t, err, errUnknownColumnNames)
+
+	// Out of range reports the index problem, not the missing names.
+	_, err = chunk.ColumnName(2)
+	require.ErrorContains(t, err, columnCountErrMsg)
+}

--- a/errors.go
+++ b/errors.go
@@ -56,8 +56,16 @@ func columnIndexError(idx int, max uint64) error {
 	return fmt.Errorf("%s: %d is out of range [0, %d)", columnIndexErrMsg, idx, max)
 }
 
+func rowIndexError(idx, max int) error {
+	return fmt.Errorf("%s: %d is out of range [0, %d)", rowIndexErrMsg, idx, max)
+}
+
 func unsupportedTypeError(name string) error {
 	return fmt.Errorf("%s: %s", unsupportedTypeErrMsg, name)
+}
+
+func unexpectedTypeError(actual, expected Type) error {
+	return fmt.Errorf("%s: expected %s, got %s", unexpectedTypeErrMsg, typeName(expected), typeName(actual))
 }
 
 func invalidatedAppenderError(err error) error {
@@ -109,6 +117,8 @@ const (
 	duplicateNameErrMsg         = "duplicate name"
 	paramIndexErrMsg            = "invalid parameter index"
 	columnIndexErrMsg           = "invalid column index"
+	rowIndexErrMsg              = "invalid row index"
+	unexpectedTypeErrMsg        = "unexpected column type"
 )
 
 var (

--- a/errors.go
+++ b/errors.go
@@ -127,6 +127,8 @@ var (
 	errClosedStmt        = errors.New("closed statement")
 	errUninitializedStmt = errors.New("uninitialized statement")
 
+	errClosedChunk = errors.New("closed data chunk")
+
 	errPrepare                    = errors.New("could not prepare query")
 	errMissingPrepareContext      = errors.New("missing context for multi-statement query: try using PrepareContext")
 	errEmptyQuery                 = errors.New("empty query")

--- a/errors.go
+++ b/errors.go
@@ -64,6 +64,10 @@ func unsupportedTypeError(name string) error {
 	return fmt.Errorf("%s: %s", unsupportedTypeErrMsg, name)
 }
 
+func invalidConnError(driverConn any) error {
+	return fmt.Errorf("%w: %T", errInvalidCon, driverConn)
+}
+
 func unexpectedTypeError(actual, expected Type) error {
 	return fmt.Errorf("%s: expected %s, got %s", unexpectedTypeErrMsg, typeName(expected), typeName(actual))
 }
@@ -139,6 +143,8 @@ var (
 
 	errClosedChunk        = errors.New("closed data chunk")
 	errUnknownColumnNames = errors.New("column names are not available for this data chunk")
+	errNilConn            = errors.New("nil sql.Conn")
+	errNilChunkConsumer   = errors.New("nil data chunk consumer")
 
 	errPrepare                    = errors.New("could not prepare query")
 	errMissingPrepareContext      = errors.New("missing context for multi-statement query: try using PrepareContext")

--- a/errors.go
+++ b/errors.go
@@ -127,7 +127,8 @@ var (
 	errClosedStmt        = errors.New("closed statement")
 	errUninitializedStmt = errors.New("uninitialized statement")
 
-	errClosedChunk = errors.New("closed data chunk")
+	errClosedChunk        = errors.New("closed data chunk")
+	errUnknownColumnNames = errors.New("column names are not available for this data chunk")
 
 	errPrepare                    = errors.New("could not prepare query")
 	errMissingPrepareContext      = errors.New("missing context for multi-statement query: try using PrepareContext")

--- a/rows_test.go
+++ b/rows_test.go
@@ -1,0 +1,36 @@
+package duckdb
+
+import (
+	"context"
+	"database/sql/driver"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRowsNextRepeatsEOF pins the driver.Rows contract: once a result is
+// exhausted, Next keeps reporting io.EOF.
+func TestRowsNextRepeatsEOF(t *testing.T) {
+	c := newConnectorWrapper(t, "", nil)
+	defer closeConnectorWrapper(t, c)
+	conn := openDriverConnWrapper(t, c)
+	defer closeDriverConnWrapper(t, &conn)
+
+	queryer, ok := conn.(driver.QueryerContext)
+	require.True(t, ok)
+
+	rows, err := queryer.QueryContext(context.Background(), "SELECT i FROM range(3) AS values(i)", nil)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	dst := make([]driver.Value, 1)
+	for i := range 3 {
+		require.NoError(t, rows.Next(dst))
+		require.Equal(t, int64(i), dst[0])
+	}
+
+	for range 3 {
+		require.ErrorIs(t, rows.Next(dst), io.EOF)
+	}
+}

--- a/vector_getters.go
+++ b/vector_getters.go
@@ -1,6 +1,7 @@
 package duckdb
 
 import (
+	"bytes"
 	"encoding/json"
 	"maps"
 	"math/big"
@@ -174,6 +175,14 @@ func (vec *vector) getBigNum(rowIdx mapping.IdxT) *big.Int {
 }
 
 func (vec *vector) getBytes(rowIdx mapping.IdxT) any {
+	view := vec.getBytesView(rowIdx)
+	if vec.Type == TYPE_VARCHAR {
+		return strings.Clone(unsafe.String(unsafe.SliceData(view), len(view)))
+	}
+	return bytes.Clone(view)
+}
+
+func (vec *vector) getBytesView(rowIdx mapping.IdxT) []byte {
 	// Use a pointer directly into C-allocated vector memory rather than a stack copy.
 	// cgo declares duckdb_string_t with alignment 1, so a stack copy (via getPrimitive)
 	// may land at an odd address. Reading the out-of-line pointer field at offset 8
@@ -186,18 +195,13 @@ func (vec *vector) getBytes(rowIdx mapping.IdxT) any {
 	// at offset 4, otherwise a pointer at offset 8 (see duckdb.h string_t::INLINE_LENGTH).
 	// NOTE: INLINE_LENGTH (12) is not exposed via the C API and could change in a future
 	// DuckDB version. If string tests start failing after a DuckDB upgrade, check here first.
-	var data string
+	var dataPtr unsafe.Pointer
 	if length <= 12 {
-		ptr := unsafe.Add(unsafe.Pointer(strTPtr), 4)
-		data = unsafe.String((*byte)(ptr), int(length))
+		dataPtr = unsafe.Add(unsafe.Pointer(strTPtr), 4)
 	} else {
-		dataPtr := *(*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(strTPtr), 8))
-		data = unsafe.String((*byte)(dataPtr), int(length))
+		dataPtr = *(*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(strTPtr), 8))
 	}
-	if vec.Type == TYPE_VARCHAR {
-		return strings.Clone(data)
-	}
-	return []byte(data)
+	return unsafe.Slice((*byte)(dataPtr), int(length))
 }
 
 func (vec *vector) getBit(rowIdx mapping.IdxT) Bit {


### PR DESCRIPTION
## Summary

Adds `QueryChunksContext`, which executes a query and hands DuckDB's native data chunks to a callback, so a caller can read a result without the per-row copy allocations that `database/sql` performs.

This extension is intended for use cases where the result is only *forwarded* rather than scanned into Go values (e.g. serialize to NDJSON/CSV and write it to a socket, a file, or another process). On that path every `rows.Scan` allocation becomes a significant overhead as the value is copied out of the vector, boxed into a `driver.Value`, copied again into the destination, and then immediately discarded. Reading it through `database/sql` allocated roughly two objects per row, so a large result turned into millions of short-lived allocations.

There were two pre-existing `duckdb-go` bugs found and addressed as they directly impacted the mechanics behind chunk query functionality.

Both bug fixes are included in this PR as separate commits:

### **`Join the context interrupter on panic`**
`runWithCtxInterrupt` closed its done channel and joined the interrupter goroutine only on the normal return path. If `fn` panicked, the goroutine survived the call and went on calling `duckdb_interrupt` on a connection `database/sql` had already discarded and closed, faulting inside cgo. Found while testing a panicking callback.

### **`Invalidate data chunks on close`**
`close` freed the C chunk but left the `DataChunk` vectors pointing into that memory, so every getter and setter kept reading and writing it.

## Motivation

This feature extension came out of adding server-side SQL over stored objects to [AIStore](https://github.com/NVIDIA/aistore) (NVIDIA's open-source, MIT-licensed storage stack for AI applications). Currently AIStore returns the full object a client requests but with a `duckdb-go` integration, a `GET` can instead carry a SQL statement that `DuckDB` can 1. validate, 2. run against the locally stored object, and 3. stream the projected/filtered result back to the client.

AIStore needs this path to be both efficient and reliable. This PR addresses both concerns: the chunk API removes the per-row allocations, and two pre-existing `duckdb-go` bugs that the integration surfaced are fixed here as well. Nothing about the API itself is specific to this use case, it applies to any export or streaming path where rows are forwarded rather than inspected, and both bug fixes are independent of the new API entirely.

## Lifetime and ownership

The library owns every C allocation involved. The result is destroyed on return, each chunk is freed once `consume` has seen it, and the prepared statement is closed even if `consume` panics.

The views alias vector memory and are valid only until the chunk is released (the same behavior as `driver.Rows.Next`, whose `[]byte` values are only valid until the next call). Because a caller can trivially retain the `*DataChunk` past its callback, accessing a released chunk now returns `errClosedChunk` rather than reading freed memory.

## API Usage 

```go
err := duckdb.QueryChunksContext(ctx, conn, query, func(chunk *duckdb.DataChunk) error {
    for row := range chunk.GetSize() {
        value, notNull, err := chunk.GetVarcharView(0, row)
        if err != nil {
            return err
        }
        if notNull {
            buf = append(buf, value...)
        }
    }
    return nil
})
```

- `QueryChunksContext(ctx, *sql.Conn, query, consume, args...)`: invokes the consume function on every chunk until all query result chunks have been consumed. Returning an error from `consume` stops iteration and returns that error unchanged, so a sentinel can stop early.
- `DataChunk.GetVarcharView` / `GetBlobView`: the bytes where DuckDB already holds them.
- `DataChunk.ColumnNames` / `ColumnName`: the names of columns in `DataChunk`.
- args: converted the same way `database/sql` converts them, so a query accepts the same types on both paths.

See `chunk_query_bench_test.go` file for usage example.

## Benchmark

This PR also creates a `chunk_query_bench_test.go` file to benchmark the performance improvement that the native chunk query API provides over the `database/sql` usage.

The benchmark serializes 100k rows to a single VARCHAR column and appends it into a reusable
buffer (`BenchmarkQueryChunks` vs `BenchmarkQueryRows`):

| | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| `QueryChunksContext` + views | 13,216,832 | 10,952 | **266** |
| `database/sql` rows + `Scan` | 16,206,268 | 6,410,840 | **200,226** |

~750x fewer allocations, ~580x less garbage, ~19% less wall time.

## Commits

Each builds and passes tests on its own:

1. `Join the context interrupter on panic`
2. `Extract a borrowed-bytes vector getter`
3. `Invalidate data chunks on close`
4. `Add data chunk column name accessors`
5. `Add borrowed views for VARCHAR and BLOB values`
6. `Add QueryChunksContext`

Commits 1 & 3 are duckdb-go fixes that affect chunk query implementation.
Commits 2, 4 & 5 provide helpers necessary for chunk query implementation.
Commit 6 introduces the core native chunk query API with full test suite and benchmark. 

## Test plan

- [x] **Iteration**: `TestQueryChunksContext` (multi-chunk result, every row seen exactly once), `TestQueryChunksContextMultipleStmts` (only the last statement yields chunks), `TestQueryChunksContextNoRows` (`consume` not called for an empty result), `TestQueryChunksContextArgs` (positional and `sql.Named`)
- [x] **Value views**: `TestQueryChunksContextViews` (NULL vs. empty string, type mismatch, out-of-range row), `TestQueryChunksContextInlineBoundary` (lengths 1/11/12/13/24, i.e. both sides of the `string_t` inline length where decoding switches from inlined bytes to an out-of-line pointer)
- [x] **Column metadata**: `TestQueryChunksContextColumnNames`
- [x] **Chunk lifetime**: `TestQueryChunksContextAfterClose`: a retained chunk returns `errClosedChunk` from every getter and setter instead of reading freed memory
- [x] **Cancellation**: `TestQueryChunksContextCancel` (stops mid-stream, the connection stays usable afterwards), `TestQueryChunksContextCanceledBeforeCall` (`consume` never runs)
- [x] **Errors and panics**: `TestQueryChunksContextQueryError`, `TestQueryChunksContextConsumerError` (sentinel returned unchanged), `TestQueryChunksContextConsumerPanic`, `TestQueryChunksContextRejectsNilConsumer`, `TestQueryChunksContextRejectsNilConnection`, `TestRunWithCtxInterrupt_PanicJoinsInterrupter`
- [x] **No leaked C memory**: under `-tags=debug_bindings` the bindings' allocation counters are zero after each of: happy path, consumer error mid-stream, query error, unsupported column type, panicking consumer
- [x] **Full suite** green plain, under `-race`, and under `-tags=debug_bindings`