### PR TITLE
fix: stop interrupt retry wait promptly

### DIFF
--- a/context.go
+++ b/context.go
@@ -107,23 +107,31 @@ func runWithCtxInterrupt(ctx context.Context, conn mapping.Connection, fn func(c
 }
 
 func interrupterRoutine(ctx context.Context, conn mapping.Connection, done <-chan struct{}, bgDoneCh chan<- struct{}) {
+	defer close(bgDoneCh)
+
 	select {
 	case <-ctx.Done():
 	case <-done:
 		// finished before cancellation
-		close(bgDoneCh)
 		return
 	}
 
 	// Re-assert interruption until the wrapped function finishes.
+	ticker := time.NewTicker(interruptInterval)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-done:
-			close(bgDoneCh)
 			return
 		default:
 			mapping.Interrupt(conn)
-			time.Sleep(interruptInterval)
+		}
+
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
 		}
 	}
 }

--- a/context_test.go
+++ b/context_test.go
@@ -113,6 +113,46 @@ func TestRunWithCtxInterrupt_Cancel_RepeatsUntilDone(t *testing.T) {
 	require.Equal(t, finalCount, count.Load(), "Interrupt should not be called after fn returns")
 }
 
+func TestRunWithCtxInterrupt_Cancel_ReturnsPromptlyAfterDone(t *testing.T) {
+	patchVar(t, &interruptInterval, time.Hour)
+
+	interrupted := make(chan struct{}, 1)
+	patchVar(t, &mapping.Interrupt, func(_ mapping.Connection) {
+		select {
+		case interrupted <- struct{}{}:
+		default:
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := make(chan struct{})
+	allowReturn := make(chan struct{})
+	doneErrCh := make(chan error, 1)
+
+	var dummyConn mapping.Connection
+	go func() {
+		doneErrCh <- runWithCtxInterrupt(ctx, dummyConn, func(_ context.Context) error {
+			close(started)
+			<-allowReturn
+			return nil
+		})
+	}()
+
+	<-started
+	cancel()
+	<-interrupted
+	close(allowReturn)
+
+	select {
+	case err := <-doneErrCh:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("runWithCtxInterrupt did not return promptly after fn completed")
+	}
+}
+
 // Test that recursively wrapping with the same context only spawns a single interrupter goroutine.
 func TestRunWithCtxInterrupt_RecursiveOnlyOneGoroutine(t *testing.T) {
 	// Set a high interval to ensure only one call per goroutine until deadline set below


### PR DESCRIPTION
## Summary

- make the context interrupter wake immediately when the wrapped DuckDB call finishes
- preserve repeated `duckdb_interrupt` calls while cancellation is active
- add a regression test for the shutdown latency

## Root cause

After a context was canceled, `interrupterRoutine` called `mapping.Interrupt` and then used an unconditional 500 ms `time.Sleep`. `runWithCtxInterrupt` correctly waits for that goroutine before returning so a late interrupt cannot affect the next query on the connection. However, when the wrapped DuckDB call finished during the sleep, the caller had to wait for the remainder of the interval.

The retry wait now selects between the interval ticker and the call's `done` channel. This keeps the existing connection-safety guarantee while allowing prompt shutdown.

In a local cancellation-heavy COPY reproducer, 50 timed-out operations completed in 1.09 seconds after this change, compared with 26.25 seconds before it.

## Validation

- `go test -run '^TestRunWithCtxInterrupt' -count=20 -timeout=60s`
- `go test -race -run '^TestRunWithCtxInterrupt' -count=5 -timeout=120s`
- `go test ./... -count=1 -timeout=15m`
- `go test -race -count=1 ./... -timeout=15m`
- `go vet ./...`
- `golangci-lint v2.12.2 run`
