### PR TITLE
Fix/pin golangci-lint

### DIFF
--- a/.github/workflows/tidy_checks.yml
+++ b/.github/workflows/tidy_checks.yml
@@ -22,7 +22,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.13.1
 
   coverage:
     name: Go Test Coverage

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,7 +65,8 @@ formatters:
         - default
         - prefix(github.com/duckdb/duckdb-go)
     gofumpt:
-      extra-rules: true
+      extra:
+        group-params: true
     goimports:
       local-prefixes:
         - github.com/duckdb/duckdb-go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - err113
     - exhaustive
     - exhaustruct
+    - exhaustruct_v5
     - forbidigo
     - funlen
     - gochecknoglobals


### PR DESCRIPTION
https://github.com/duckdb/duckdb-go/actions/runs/32714424923/job/97392550429 just failed after #172 was green.

This change keeps lint results stable between pull request and post-merge runs.