### PR TITLE
fix: preserve precision when decoding JSON numbers

### DIFF
--- a/types_test.go
+++ b/types_test.go
@@ -160,8 +160,8 @@ func testTypesGenerateRow[T require.TestingT](t T, i int) testTypesRow {
 	}
 	jsonMapCol := Composite[map[string]any]{
 		map[string]any{
-			"hello": float64(42),
-			"world": float64(84),
+			"hello": json.Number("42"),
+			"world": json.Number("84"),
 		},
 	}
 	jsonArrayCol := Composite[[]any]{
@@ -1337,9 +1337,20 @@ func TestJSONType(t *testing.T) {
 
 	var res Composite[map[string]any]
 	require.NoError(t, row.Scan(&res))
-	require.Equal(t, float64(1), res.Get()["1"])
-	require.Equal(t, float64(2), res.Get()["2"])
-	require.Equal(t, float64(3), res.Get()["3"])
+	require.Equal(t, json.Number("1"), res.Get()["1"])
+	require.Equal(t, json.Number("2"), res.Get()["2"])
+	require.Equal(t, json.Number("3"), res.Get()["3"])
+}
+
+func TestJSONNumberPreservesPrecision(t *testing.T) {
+	db := openDbWrapper(t, ``)
+	defer closeDbWrapper(t, db)
+
+	var value any
+	require.NoError(t, db.QueryRow(`SELECT '{"n":50000.0000000000000001}'::JSON`).Scan(&value))
+	encoded, err := json.Marshal(value)
+	require.NoError(t, err)
+	require.Equal(t, `{"n":50000.0000000000000001}`, string(encoded))
 }
 
 func TestJSONColType(t *testing.T) {

--- a/vector_getters.go
+++ b/vector_getters.go
@@ -1,6 +1,7 @@
 package duckdb
 
 import (
+	"bytes"
 	"encoding/json"
 	"maps"
 	"math/big"
@@ -224,7 +225,9 @@ func (vec *vector) getJSON(rowIdx mapping.IdxT) (any, error) {
 		return nil, errInternal
 	}
 	var value any
-	if err := json.Unmarshal([]byte(data), &value); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader([]byte(data)))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
 		return nil, err
 	}
 	return value, nil

--- a/vector_view_test.go
+++ b/vector_view_test.go
@@ -2,6 +2,7 @@ package duckdb
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"unsafe"
@@ -175,7 +176,7 @@ func TestVarcharVectorViewRejectsJSONAlias(t *testing.T) {
 
 	owned, err := chunk.GetValue(0, 0)
 	require.NoError(t, err)
-	require.Equal(t, map[string]any{"answer": float64(42)}, owned)
+	require.Equal(t, map[string]any{"answer": json.Number("42")}, owned)
 }
 
 type vectorViewIdentityUDF struct {


### PR DESCRIPTION
## Summary

Decode DuckDB JSON values with `json.Decoder.UseNumber()` instead of the default `float64` conversion. This prevents precision loss before callers can marshal or otherwise consume JSON values.

For example, `{"n":50000.0000000000000001}` currently round-trips through the driver as `{"n":50000}`. With this change, the original numeric lexeme is preserved as `json.Number`.

## Validation

- Added an exact JSON numeric round-trip regression test
- Updated JSON value expectations to `json.Number`
- `go test ./...` passes